### PR TITLE
fix: updated type of data received to fix captureenvelope and getstringbyteslength android methods

### DIFF
--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -46,11 +46,12 @@ public class SentryCapacitor extends Plugin {
 
         if (this.context == null) {
             this.context = this.bridge.getContext();
-            try {
-                this.packageInfo = this.context.getPackageManager().getPackageInfo(this.getContext().getPackageName(), 0);
-            } catch (Exception e) {
-                logger.info("Error getting package info.");
-            }
+        }
+
+        try {
+            this.packageInfo = this.context.getPackageManager().getPackageInfo(this.getContext().getPackageName(), 0);
+        } catch (Exception e) {
+            logger.info("Error getting package info.");
         }
     }
 
@@ -95,19 +96,6 @@ public class SentryCapacitor extends Plugin {
 
                 options.setBeforeSend(
                     (event, hint) -> {
-                        // TODO Need to look into whether this is needed for Capacitor
-                        // React native internally throws a JavascriptException
-                        // Since we catch it before that, we don't want to send this one
-                        // because we would send it twice
-                        // try {
-                        //     SentryException ex = event.getExceptions().get(0);
-                        //     if (null != ex && ex.getType().contains("JavascriptException")) {
-                        //         return null;
-                        //     }
-                        // } catch (Exception e) {
-                        //     // We do nothing
-                        // }
-
                         // Add on the correct event.origin tag.
                         // it needs to be here so we can determine where it originated from.
                         SdkVersion sdkVersion = event.getSdk();
@@ -199,11 +187,13 @@ public class SentryCapacitor extends Plugin {
             } catch (Exception e) {
                 logger.info("Error writing envelope.");
                 call.reject(String.valueOf(e));
+                return;
             }
         }
         catch (Exception e) {
             logger.info("Error reading envelope.");
             call.reject(String.valueOf(e));
+            return;
         }
     }
     
@@ -218,6 +208,8 @@ public class SentryCapacitor extends Plugin {
             } catch (UnsupportedEncodingException e) {
                 call.reject(String.valueOf(e));
             }
+        } else {
+            call.reject("Could not calculate string length.");
         }
     }
 
@@ -289,6 +281,7 @@ public class SentryCapacitor extends Plugin {
         Sentry.configureScope(scope -> {
             scope.setExtra(key, extra);
         });
+        call.resolve();
     }
 
     @PluginMethod
@@ -298,5 +291,6 @@ public class SentryCapacitor extends Plugin {
         Sentry.configureScope(scope -> {
             scope.setTag(key, value);
         });
+        call.resolve();
     }
 }

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,6 +1,7 @@
 import { BrowserOptions, Transports } from '@sentry/browser';
 import { BrowserBackend } from '@sentry/browser/dist/backend';
 import { BaseBackend, NoopTransport } from '@sentry/core';
+import { Event, EventHint, Severity, Transport } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { CapacitorOptions } from './options';
@@ -37,7 +38,29 @@ export class CapacitorBackend extends BaseBackend<BrowserOptions> {
   /**
    * @inheritDoc
    */
-  protected _setupCapacitorTransport(): Transport | NoopTransport {
+  public eventFromException(
+    exception: unknown,
+    hint?: EventHint,
+  ): PromiseLike<Event> {
+    return this._browserBackend.eventFromException(exception, hint);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public eventFromMessage(
+    message: string,
+    level: Severity = Severity.Info,
+    hint?: EventHint,
+  ): PromiseLike<Event> {
+    /* eslint-disable no-console */
+    return this._browserBackend.eventFromMessage(message, level, hint);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected _setupTransport(): Transport | NoopTransport {
     if (!this._options.dsn) {
       // We return the noop transport here in case there is no Dsn.
       return new NoopTransport();
@@ -58,16 +81,6 @@ export class CapacitorBackend extends BaseBackend<BrowserOptions> {
 
     return new Transports.FetchTransport(transportOptions);
   }
-
-  /**
-   * Has Capacitor on window?
-   */
-  // private _isCapacitor(): boolean {
-  //   return (
-  //     getGlobalObject<any>().capacitor !== undefined ||
-  //     getGlobalObject<any>().Capacitor !== undefined
-  //   );
-  // }
 
   /**
    * If true, native client is availabe and active

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -14,7 +14,7 @@ interface serializedObject {
 
 export interface SentryCapacitorPlugin {
   addBreadcrumb(breadcrumb: Breadcrumb): void;
-  captureEnvelope(envelope: string): PromiseLike<Response>;
+  captureEnvelope(payload: { envelope: string }): PromiseLike<Response>;
   clearBreadcrumbs(): void;
   crash(): void;
   fetchRelease(): Promise<{
@@ -22,7 +22,7 @@ export interface SentryCapacitorPlugin {
     id: string;
     version: string;
   }>;
-  getStringBytesLength(payloadString: string): number;
+  getStringBytesLength(payload: { string: string }): Promise<{ value: number }>;
   startWithOptions(options: CapacitorOptions): Promise<boolean>;
   setUser(
     user: serializedObject | null,

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,8 +27,10 @@ export class SentryCapacitorWeb
   /**
    *
    */
-  captureEnvelope(): Promise<Response> {
+  captureEnvelope(payload: { envelope: string }): Promise<Response> {
     // TODO integrate web
+    /* eslint-disable-next-line no-console */
+    console.log(payload.envelope);
     return Promise.resolve({
       status: Status.Success,
     });
@@ -67,11 +69,13 @@ export class SentryCapacitorWeb
   /**
    *
    */
-  getStringBytesLength(payloadString: 'somepayload'): number {
+  getStringBytesLength(payload: {
+    string: string;
+  }): Promise<{ value: number }> {
     // TODO integrate web
     /* eslint-disable-next-line no-console */
-    console.log(payloadString);
-    return 12;
+    console.log(payload.string);
+    return Promise.resolve({ value: 12 });
   }
 
   /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,10 +27,10 @@ export class SentryCapacitorWeb
   /**
    *
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   captureEnvelope(payload: { envelope: string }): Promise<Response> {
     // TODO integrate web
-    /* eslint-disable-next-line no-console */
-    console.log(payload.envelope);
+
     return Promise.resolve({
       status: Status.Success,
     });
@@ -69,22 +69,20 @@ export class SentryCapacitorWeb
   /**
    *
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getStringBytesLength(payload: {
     string: string;
   }): Promise<{ value: number }> {
     // TODO integrate web
-    /* eslint-disable-next-line no-console */
-    console.log(payload.string);
     return Promise.resolve({ value: 12 });
   }
 
   /**
    *
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async startWithOptions(options: CapacitorOptions): Promise<boolean> {
     // TODO integrate web
-    /* eslint-disable-next-line no-console */
-    console.log(options);
     return true;
   }
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -39,12 +39,15 @@ export const NATIVE = {
       },
     };
 
-    const headerString = JSON.stringify(header);
-
-    const payloadString = JSON.stringify(payload);
+    const headerString: string = JSON.stringify(header);
+    const payloadString: string = JSON.stringify(payload);
     let length = payloadString.length;
     try {
-      length = await SentryCapacitor.getStringBytesLength(payloadString);
+      void SentryCapacitor.getStringBytesLength({ string: payloadString }).then(
+        resp => {
+          length = resp.value;
+        },
+      );
     } catch {
       // The native call failed, we do nothing, we have payload.length as a fallback
     }
@@ -58,7 +61,7 @@ export const NATIVE = {
     const itemString = JSON.stringify(item);
 
     const envelopeString = `${headerString}\n${itemString}\n${payloadString}`;
-    return SentryCapacitor.captureEnvelope(envelopeString);
+    return SentryCapacitor.captureEnvelope({ envelope: envelopeString });
   },
 
   /**

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -1,11 +1,14 @@
 import { CapacitorBackend } from '../src/backend';
 
-// const EXAMPLE_DSN =
-//   'https://6890c2f6677340daa4804f8194804ea2@o19635.ingest.sentry.io/148053';
+const EXAMPLE_DSN =
+  'https://6890c2f6677340daa4804f8194804ea2@o19635.ingest.sentry.io/148053';
 
 jest.mock(
   '@capacitor/core',
   () => ({
+    Capacitor: {
+      isPluginAvailable: jest.fn(() => true),
+    },
     Plugins: {
       SentryCapacitor: {
         crash: jest.fn(),
@@ -26,15 +29,14 @@ jest.mock(
 
 describe('Tests CapacitorBackend', () => {
   describe('initializing the backend', () => {
-    // TODO add these in once eventFromMessage method is in progress
-    // test('backend initializes', async () => {
-    //   const backend = new CapacitorBackend({
-    //     dsn: EXAMPLE_DSN,
-    //     enableNative: true,
-    //   });
+    test('backend initializes', async () => {
+      const backend = new CapacitorBackend({
+        dsn: EXAMPLE_DSN,
+        enableNative: true,
+      });
 
-    //   await expect(backend.eventFromMessage('test')).resolves.toBeDefined();
-    // });
+      await expect(backend.eventFromMessage('test')).resolves.toBeDefined();
+    });
 
     test('invalid dsn is thrown', () => {
       try {
@@ -47,16 +49,15 @@ describe('Tests CapacitorBackend', () => {
       }
     });
 
-    // TODO add these in once eventFromMessage method is in progress
-    // test("undefined dsn doesn't crash", () => {
-    //   expect(() => {
-    //     const backend = new CapacitorBackend({
-    //       dsn: undefined,
-    //       enableNative: true,
-    //     });
+    test("undefined dsn doesn't crash", () => {
+      expect(() => {
+        const backend = new CapacitorBackend({
+          dsn: undefined,
+          enableNative: true,
+        });
 
-    //     return expect(backend.eventFromMessage('test')).resolves.toBeDefined();
-    //   }).not.toThrow();
-    // });
+        return expect(backend.eventFromMessage('test')).resolves.toBeDefined();
+      }).not.toThrow();
+    });
   });
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -21,7 +21,7 @@ jest.mock(
             version: '0.0.1',
           });
         }),
-        getStringBytesLength: jest.fn(() => Promise.resolve(1)),
+        getStringBytesLength: jest.fn(() => Promise.resolve({ value: 1 })),
         sendEvent: jest.fn(() => Promise.resolve()),
         setUser: jest.fn(() => {
           return;
@@ -117,13 +117,15 @@ describe('Tests Native Wrapper', () => {
 
       const item = JSON.stringify({
         content_type: 'application/json',
-        length: 1,
+        length: 114,
         type: 'event',
       });
 
-      await expect(NATIVE.sendEvent(event)).resolves.toMatch(
-        `${header}\n${item}\n${payload}`,
-      );
+      const response = {
+        envelope: `${header}\n${item}\n${payload}`,
+      };
+
+      await expect(NATIVE.sendEvent(event)).resolves.toMatchObject(response);
     });
 
     test('does not call Capacitor at all if enableNative is false', async () => {


### PR DESCRIPTION
This implements the captureMessage and captureException functionality in android and in the JS middleware. There are also fixes to the tests and updates to the type of data being sent to captureEnvelope and getStringBytesLength (the wrong data was previously being sent).

Testing of both the captureException and captureMessage methods was used in a project I created on the Sentry website, and both events were successfully sent: 
![Screen Shot 2020-11-18 at 1 22 44 PM](https://user-images.githubusercontent.com/42003899/99571345-28728780-29a1-11eb-8dd3-0f22eb8e3ee5.png)
