### PR TITLE
build(android): Bump sentry-android to 5.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation 'io.sentry:sentry-android:5.0.0'
+    implementation 'io.sentry:sentry-android:5.0.1'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation 'io.sentry:sentry-android:5.0.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation 'io.sentry:sentry-android:4.3.0'
+    implementation 'io.sentry:sentry-android:5.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -193,7 +193,7 @@ public class SentryCapacitor extends Plugin {
             String envelope = call.getString("envelope");
             final String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();
 
-            if (outboxPath == null && outboxPath.isEmpty()) {
+            if (outboxPath == null || outboxPath.isEmpty()) {
                 logger.info("Error when writing envelope, no outbox path is present.");
                 call.reject("Missing outboxPath");
                 return;

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -5,7 +5,6 @@ import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
-import com.google.gson.Gson;
 
 import io.sentry.Breadcrumb;
 import io.sentry.HubAdapter;
@@ -26,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -272,12 +272,13 @@ public class SentryCapacitor extends Plugin {
 
             if (breadcrumb.getData().has("data")) {
                 JSObject data = breadcrumb.getObject("data");
-                HashMap<String, String> mappedData = new Gson().fromJson(data.toString(), HashMap.class);
+                Iterator<String> it = data.keys();
 
-                for ( HashMap.Entry<String, String> entry: mappedData.entrySet()) {
-                    String key = entry.getKey();
-                    String value = entry.getValue();
-                    breadcrumbInstance.setData(key, value);
+                while (it.hasNext()) {
+                  String key = it.next();
+                  String value = data.getString(key);
+
+                  breadcrumbInstance.setData(key, value);
                 }
             }
 

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -192,6 +192,13 @@ public class SentryCapacitor extends Plugin {
         try {
             String envelope = call.getString("envelope");
             final String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();
+
+            if (outboxPath != null && !outboxPath.trim().isEmpty()) {
+                logger.info("Error when writing envelope, no outbox path is present.");
+                call.reject("Missing outboxPath");
+                return;
+            }
+
             final File installation =  new File(outboxPath, UUID.randomUUID().toString());
 
             try (FileOutputStream out = new FileOutputStream(installation)) {

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -12,12 +12,13 @@ import io.sentry.HubAdapter;
 import io.sentry.Integration;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
-import io.sentry.SentryOptions;
+import io.sentry.SentryEvent;
 import io.sentry.UncaughtExceptionHandlerIntegration;
 import io.sentry.android.core.AnrIntegration;
 import io.sentry.android.core.NdkIntegration;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.protocol.SdkVersion;
+import io.sentry.protocol.SentryPackage;
 import io.sentry.protocol.User;
 
 import java.io.File;
@@ -118,6 +119,8 @@ public class SentryCapacitor extends Plugin {
                                 }
                             }
                         }
+
+                        addPackages(event, options.getSdkVersion());
 
                         return event;
                     }
@@ -332,4 +335,26 @@ public class SentryCapacitor extends Plugin {
         }
         call.resolve();
     }
+
+    @PluginMethod
+    public void addPackages(SentryEvent event, SdkVersion sdk) {
+        SdkVersion eventSdk = event.getSdk();
+        if (eventSdk != null && eventSdk.getName().equals("sentry.javascript.capacitor") && sdk != null) {
+            List<SentryPackage> sentryPackages = sdk.getPackages();
+            if (sentryPackages != null) {
+                for (SentryPackage sentryPackage : sentryPackages) {
+                    eventSdk.addPackage(sentryPackage.getName(), sentryPackage.getVersion());
+                }
+            }
+
+            List<String> integrations = sdk.getIntegrations();
+            if (integrations != null) {
+                for (String integration : integrations) {
+                    eventSdk.addIntegration(integration);
+                }
+            }
+
+            event.setSdk(eventSdk);
+        }
+      }
 }

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -193,7 +193,7 @@ public class SentryCapacitor extends Plugin {
             String envelope = call.getString("envelope");
             final String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();
 
-            if (outboxPath != null && !outboxPath.trim().isEmpty()) {
+            if (outboxPath == null && outboxPath.isEmpty()) {
                 logger.info("Error when writing envelope, no outbox path is present.");
                 call.reject("Missing outboxPath");
                 return;

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -205,7 +205,6 @@ public class SentryCapacitor extends Plugin {
 
     @PluginMethod
     public void captureEnvelope(PluginCall call) {
-        
         try {
             String envelope = call.getString("envelope");
             final String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -15,7 +15,7 @@ export const NATIVE = {
    * Sending the event over the bridge to native
    * @param event Event
    */
-  async sendEvent(event: Event): Promise<Response> {
+  async sendEvent(_event: Event): Promise<Response> {
     if (!this.enableNative) {
       throw this._DisabledNativeError;
     }
@@ -23,8 +23,7 @@ export const NATIVE = {
       throw this._NativeClientError;
     }
 
-    // Process and convert deprecated levels
-    event.level = event.level ? this._processLevel(event.level) : undefined;
+    const event = this._processLevels(_event);
 
     const header = {
       event_id: event.event_id,
@@ -257,6 +256,26 @@ export const NATIVE = {
     });
 
     return serialized;
+  },
+
+  /**
+   * Convert js severity level in event.level and event.breadcrumbs to more widely supported levels.
+   * @param event
+   * @returns Event with more widely supported Severity level strings
+   */
+  _processLevels(event: Event): Event {
+    const processed: Event = {
+      ...event,
+      level: event.level ? this._processLevel(event.level) : undefined,
+      breadcrumbs: event.breadcrumbs?.map(breadcrumb => ({
+        ...breadcrumb,
+        level: breadcrumb.level
+          ? this._processLevel(breadcrumb.level)
+          : undefined,
+      })),
+    };
+
+    return processed;
   },
 
   /**


### PR DESCRIPTION
Bumps the Sentry Android SDK to 5.0.1.

Additional Changes:
- Updates the `captureEnvelope` method to get the outboxPath from `HubAdapter`. A recent fix in React Native.
- Adds the native SDK's packages to the sdk info on events sent from the JS layer.
- Moves the event origin tag into its own method to align with other sdks.

Tested on the sample app with a multitude of events including native crashes.

<img width="457" alt="Screen Shot 2021-06-04 at 7 41 41 PM" src="https://user-images.githubusercontent.com/30991498/120802680-ec81c700-c56c-11eb-8774-d9bbb58a768a.png">
<img width="377" alt="Screen Shot 2021-06-04 at 7 42 12 PM" src="https://user-images.githubusercontent.com/30991498/120802719-f73c5c00-c56c-11eb-8b3d-b4e7fb529a30.png">
