### PR TITLE
feat: Add event origin tag and also move sdkInfo into an integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ export {
   User,
 } from '@sentry/types';
 
-import { addGlobalEventProcessor } from '@sentry/core';
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
@@ -37,37 +36,6 @@ export {
   withScope,
 } from '@sentry/core';
 
-import { SDK_NAME, SDK_VERSION } from './version';
-
+export { SDK_NAME, SDK_VERSION } from './version';
 export { CapacitorOptions } from './options';
-
 export { init, nativeCrash } from './sdk';
-
-/**
- * Adds the SDK info. Make sure this is called after @sentry/capacitor's so this is the top-level SDK.
- */
-function createCapacitorEventProcessor(): void {
-  if (addGlobalEventProcessor) {
-    addGlobalEventProcessor(event => {
-      event.platform = event.platform || 'javascript';
-      event.sdk = {
-        ...event.sdk,
-        name: SDK_NAME,
-        packages: [
-          ...((event.sdk && event.sdk.packages) || []),
-          {
-            name: 'npm:@sentry/capacitor',
-            version: SDK_VERSION,
-          },
-        ],
-        version: SDK_VERSION,
-      };
-
-      return event;
-    });
-  }
-}
-
-createCapacitorEventProcessor();
-
-export { SDK_NAME, SDK_VERSION };

--- a/src/integrations/eventorigin.ts
+++ b/src/integrations/eventorigin.ts
@@ -1,0 +1,28 @@
+import { EventProcessor, Integration } from '@sentry/types';
+
+/** Default EventOrigin instrumentation */
+export class EventOrigin implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'EventOrigin';
+
+  /**
+   * @inheritDoc
+   */
+  public name: string = EventOrigin.id;
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(addGlobalEventProcessor: (e: EventProcessor) => void): void {
+    addGlobalEventProcessor(event => {
+      event.tags = event.tags ?? {};
+
+      event.tags['event.origin'] = 'javascript';
+      event.tags['event.environment'] = 'javascript';
+
+      return event;
+    });
+  }
+}

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,0 +1,2 @@
+export { EventOrigin } from './eventorigin';
+export { SdkInfo } from './sdkinfo';

--- a/src/integrations/sdkinfo.ts
+++ b/src/integrations/sdkinfo.ts
@@ -1,0 +1,39 @@
+import { EventProcessor, Integration } from '@sentry/types';
+
+import { SDK_NAME, SDK_VERSION } from '../version';
+
+/** Default SdkInfo instrumentation */
+export class SdkInfo implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'SdkInfo';
+
+  /**
+   * @inheritDoc
+   */
+  public name: string = SdkInfo.id;
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(addGlobalEventProcessor: (e: EventProcessor) => void): void {
+    addGlobalEventProcessor(event => {
+      event.platform = event.platform || 'javascript';
+      event.sdk = {
+        ...event.sdk,
+        name: SDK_NAME,
+        packages: [
+          ...((event.sdk && event.sdk.packages) || []),
+          {
+            name: 'npm:@sentry/capacitor',
+            version: SDK_VERSION,
+          },
+        ],
+        version: SDK_VERSION,
+      };
+
+      return event;
+    });
+  }
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -6,6 +6,7 @@ import {
 import { Hub, makeMain } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
 
+import { EventOrigin, SdkInfo } from './integrations';
 import { CapacitorOptions } from './options';
 import { CapacitorScope } from './scope';
 import { NativeTransport } from './transports/native';
@@ -61,6 +62,8 @@ export function init<O>(
         return frame;
       },
     }),
+    new SdkInfo(),
+    new EventOrigin(),
   ];
 
   if (typeof finalOptions.enableNative === 'undefined') {


### PR DESCRIPTION
Adds the `event.origin` and `event.environment` tag as a default integration. Also refactors the sdk info event processor into a default integration.

Tested on sample app with multiple events.

<img width="469" alt="Screen Shot 2021-06-04 at 7 41 26 PM" src="https://user-images.githubusercontent.com/30991498/120802894-2783fa80-c56d-11eb-8680-fb724ef6de77.png">

