### PR TITLE
feat: Finish scope sync for both iOS and Android

### DIFF
--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -60,101 +60,101 @@ public class SentryCapacitor extends Plugin {
 
     @PluginMethod
     public void initNativeSdk(final PluginCall call) {
-        JSObject capOptions = call.getObject("options");
+      JSObject capOptions = call.getObject("options");
 
-        SentryAndroid.init(
-            this.getContext(),
-            options -> {
-                if (capOptions.getData().has("debug") && capOptions.getBoolean("debug")) {
-                    options.setDebug(true);
-                    logger.setLevel(Level.INFO);
-                }
+      SentryAndroid.init(
+          this.getContext(),
+          options -> {
+              if (capOptions.has("debug") && capOptions.getBool("debug")) {
+                  options.setDebug(true);
+                  logger.setLevel(Level.INFO);
+              }
 
-                String dsn = capOptions.getString("dsn") != null ? capOptions.getString("dsn") : "";
-                logger.info(String.format("Starting with DSN: '%s'", dsn));
-                options.setDsn(dsn);
+              String dsn = capOptions.getString("dsn") != null ? capOptions.getString("dsn") : "";
+              logger.info(String.format("Starting with DSN: '%s'", dsn));
+              options.setDsn(dsn);
 
-                if (capOptions.getData().has("environment") && capOptions.getString("environment") != null) {
-                    options.setEnvironment(capOptions.getString("environment"));
-                }
+              if (capOptions.has("environment") && capOptions.getString("environment") != null) {
+                  options.setEnvironment(capOptions.getString("environment"));
+              }
 
-                if (capOptions.getData().has("enableAutoSessionTracking")) {
-                    options.setEnableSessionTracking(capOptions.getBoolean("enableAutoSessionTracking"));
-                }
+              if (capOptions.has("enableAutoSessionTracking")) {
+                  options.setEnableAutoSessionTracking(capOptions.getBool("enableAutoSessionTracking"));
+              }
 
-                if (capOptions.getData().has("sessionTrackingIntervalMillis")) {
-                    options.setSessionTrackingIntervalMillis(capOptions.getInt("sessionTrackingIntervalMillis"));
-                }
+              if (capOptions.has("sessionTrackingIntervalMillis")) {
+                  options.setSessionTrackingIntervalMillis(capOptions.getInteger("sessionTrackingIntervalMillis"));
+              }
 
-                if (capOptions.getData().has("enableNdkScopeSync")) {
-                    options.setEnableScopeSync(capOptions.getBoolean("enableNdkScopeSync"));
-                }
+              if (capOptions.has("enableNdkScopeSync")) {
+                  options.setEnableScopeSync(capOptions.getBool("enableNdkScopeSync"));
+              }
 
-                if (capOptions.getData().has("attachStacktrace")) {
-                    options.setAttachStacktrace(capOptions.getBoolean("attachStacktrace"));
-                }
+              if (capOptions.has("attachStacktrace")) {
+                  options.setAttachStacktrace(capOptions.getBool("attachStacktrace"));
+              }
 
-                if (capOptions.getData().has("attachThreads")) {
-                    // JS use top level stacktraces and android attaches Threads which hides them so
-                    // by default we hide.
-                    options.setAttachThreads(capOptions.getBoolean("attachThreads"));
-                }
+              if (capOptions.has("attachThreads")) {
+                  // JS use top level stacktraces and android attaches Threads which hides them so
+                  // by default we hide.
+                  options.setAttachThreads(capOptions.getBool("attachThreads"));
+              }
 
-                options.setBeforeSend(
-                    (event, hint) -> {
-                        setEventOriginTag(event);
-                        addPackages(event, options.getSdkVersion());
+              options.setBeforeSend(
+                  (event, hint) -> {
+                      setEventOriginTag(event);
+                      addPackages(event, options.getSdkVersion());
 
-                        return event;
-                    }
-                );
+                      return event;
+                  }
+              );
 
-                if (capOptions.getData().has("enableNativeCrashHandling") && !capOptions.getBoolean("enableNativeCrashHandling")) {
-                    final List<Integration> integrations = options.getIntegrations();
-                    for (final Integration integration : integrations) {
-                        if (
-                            integration instanceof UncaughtExceptionHandlerIntegration ||
-                            integration instanceof AnrIntegration ||
-                            integration instanceof NdkIntegration
-                        ) {
-                            integrations.remove(integration);
-                        }
-                    }
-                }
+              if (capOptions.has("enableNativeCrashHandling") && !capOptions.getBool("enableNativeCrashHandling")) {
+                  final List<Integration> integrations = options.getIntegrations();
+                  for (final Integration integration : integrations) {
+                      if (
+                          integration instanceof UncaughtExceptionHandlerIntegration ||
+                          integration instanceof AnrIntegration ||
+                          integration instanceof NdkIntegration
+                      ) {
+                          integrations.remove(integration);
+                      }
+                  }
+              }
 
-                logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
-            }
-        );
+              logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
+          }
+      );
 
-        JSObject resp = new JSObject();
-        resp.put("value", true);
-        capOptions.resolve(resp);
-    }
+      JSObject resp = new JSObject();
+      resp.put("value", true);
+      call.resolve(resp);
+  }
 
     @PluginMethod
     public void setUser(PluginCall call) {
         Sentry.configureScope(scope -> {
-            if (!call.getData().has("user") && !call.getData().has("otherUserKeys")) {
+            if (!call.getData().has("defaultUserKeys") && !call.getData().has("otherUserKeys")) {
                 scope.setUser(null);
             } else {
                 User userInstance = new User();
 
-                if (call.getData().has("user")) {
-                    JSObject user = call.getObject("user");
-                    if (user.has("email")) {
-                        userInstance.setEmail(user.getString("email"));
+                if (call.getData().has("defaultUserKeys")) {
+                    JSObject defaultUserKeys = call.getObject("defaultUserKeys");
+                    if (defaultUserKeys.has("email")) {
+                        userInstance.setEmail(defaultUserKeys.getString("email"));
                     }
 
-                    if (user.has("id")) {
-                        userInstance.setId(user.getString("id"));
+                    if (defaultUserKeys.has("id")) {
+                        userInstance.setId(defaultUserKeys.getString("id"));
                     }
 
-                    if (user.has("username")) {
-                        userInstance.setUsername(user.getString("username"));
+                    if (defaultUserKeys.has("username")) {
+                        userInstance.setUsername(defaultUserKeys.getString("username"));
                     }
 
-                    if (user.has("ip_address")) {
-                        userInstance.setIpAddress(user.getString("ip_address"));
+                    if (defaultUserKeys.has("ip_address")) {
+                        userInstance.setIpAddress(defaultUserKeys.getString("ip_address"));
                     }
                 }
 
@@ -305,11 +305,11 @@ public class SentryCapacitor extends Plugin {
 
     @PluginMethod
     public void setExtra(PluginCall call) {
-        if (call.getData().has("key") && call.getData().has("extra")) {
+        if (call.getData().has("key") && call.getData().has("value")) {
             Sentry.configureScope(scope -> {
                 String key = call.getString("key");
-                String extra = call.getString("extra");
-                scope.setExtra(key, extra);
+                String value = call.getString("value");
+                scope.setExtra(key, value);
             });
         }
         call.resolve();

--- a/example/ionic-angular-v2/src/app/tab1/tab1.page.html
+++ b/example/ionic-angular-v2/src/app/tab1/tab1.page.html
@@ -49,5 +49,22 @@
       Ignore logging an error that uses excluded type
       <ion-button (click)="ignoredTypeError()">Ignored Type Error</ion-button>
     </label>
+
+    <label>
+      Set Scope Properties
+      <ion-button (click)="setScope()">Set Scope</ion-button>
+    </label>
+    <label>
+      Clear User
+      <ion-button (click)="clearUser()">Clear User</ion-button>
+    </label>
+    <label>
+      Clear Breadcrumbs
+      <ion-button (click)="clearBreadcrumbs()">Clear Breadcrumbs</ion-button>
+    </label>
+    <label>
+      Clear Test Context
+      <ion-button (click)="clearTestContext()">Clear Test Context</ion-button>
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular-v2/src/app/tab1/tab1.page.ts
+++ b/example/ionic-angular-v2/src/app/tab1/tab1.page.ts
@@ -44,4 +44,101 @@ export class Tab1Page {
       new RangeError('Exception that will be ignored because of its type'),
     );
   }
+
+  public setScope(): void {
+    const dateString = new Date().toString();
+
+    Sentry.setUser({
+      id: 'test-id-0',
+      email: 'testing@testing.test',
+      username: 'USER-TEST',
+      specialField: 'special user field',
+      specialFieldNumber: 418,
+    });
+
+    Sentry.setTag('SINGLE-TAG', dateString);
+    // @ts-ignore
+    Sentry.setTag('SINGLE-TAG-NUMBER', 100);
+    Sentry.setTags({
+      'MULTI-TAG-0': dateString,
+      'MULTI-TAG-1': dateString,
+      'MULTI-TAG-2': dateString,
+    });
+
+    Sentry.setExtra('SINGLE-EXTRA', dateString);
+    Sentry.setExtra('SINGLE-EXTRA-NUMBER', 100);
+    Sentry.setExtra('SINGLE-EXTRA-OBJECT', {
+      message: 'I am a teapot',
+      status: 418,
+      array: ['boo', 100, 400, { objectInsideArray: 'foobar' }],
+    });
+    Sentry.setExtras({
+      'MULTI-EXTRA-0': dateString,
+      'MULTI-EXTRA-1': dateString,
+      'MULTI-EXTRA-2': dateString,
+    });
+
+    Sentry.setContext('TEST-CONTEXT', {
+      stringTest: 'Hello',
+      numberTest: 404,
+      objectTest: {
+        foo: 'bar',
+      },
+      arrayTest: ['foo', 'bar', 400],
+      nullTest: null,
+      undefinedTest: undefined,
+    });
+
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Info,
+      message: `TEST-BREADCRUMB-INFO: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Debug,
+      message: `TEST-BREADCRUMB-DEBUG: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Error,
+      message: `TEST-BREADCRUMB-ERROR: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Fatal,
+      message: `TEST-BREADCRUMB-FATAL: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Info,
+      message: `TEST-BREADCRUMB-DATA: ${dateString}`,
+      data: {
+        stringTest: 'Hello',
+        numberTest: 404,
+        objectTest: {
+          foo: 'bar',
+        },
+        arrayTest: ['foo', 'bar', 400],
+        nullTest: null,
+        undefinedTest: undefined,
+      },
+      category: 'TEST-CATEGORY',
+    });
+
+    console.log('Test scope properties were set.');
+  }
+
+  public clearUser(): void {
+    Sentry.configureScope(scope => {
+      scope.setUser(null);
+    });
+  }
+
+  public clearBreadcrumbs(): void {
+    Sentry.configureScope(scope => {
+      scope.clearBreadcrumbs();
+    });
+  }
+
+  public clearTestContext(): void {
+    Sentry.configureScope(scope => {
+      scope.setContext('TEST-CONTEXT', null);
+    });
+  }
 }

--- a/example/ionic-angular-v2/yalc.lock
+++ b/example/ionic-angular-v2/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "@sentry/capacitor": {
-      "signature": "58872588b4612ed22ce4359c54dbcdd0",
+      "signature": "b1a6fdd0166b2fe57dbc432bb139dbdd",
       "file": true,
       "replaced": "file:../.."
     }

--- a/example/ionic-angular/src/app/tab1/tab1.page.html
+++ b/example/ionic-angular/src/app/tab1/tab1.page.html
@@ -49,5 +49,14 @@
       Ignore logging an error that uses excluded type
       <ion-button (click)="ignoredTypeError()">Ignored Type Error</ion-button>
     </label>
+
+    <label>
+      Set Scope Properties
+      <ion-button (click)="setScope()">Set Scope</ion-button>
+    </label>
+    <label>
+      Clear User
+      <ion-button (click)="clearUser()">Clear User</ion-button>
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular/src/app/tab1/tab1.page.html
+++ b/example/ionic-angular/src/app/tab1/tab1.page.html
@@ -62,5 +62,9 @@
       Clear Breadcrumbs
       <ion-button (click)="clearBreadcrumbs()">Clear Breadcrumbs</ion-button>
     </label>
+    <label>
+      Clear Test Context
+      <ion-button (click)="clearTestContext()">Clear Test Context</ion-button>
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular/src/app/tab1/tab1.page.html
+++ b/example/ionic-angular/src/app/tab1/tab1.page.html
@@ -58,5 +58,9 @@
       Clear User
       <ion-button (click)="clearUser()">Clear User</ion-button>
     </label>
+    <label>
+      Clear Breadcrumbs
+      <ion-button (click)="clearBreadcrumbs()">Clear Breadcrumbs</ion-button>
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular/src/app/tab1/tab1.page.ts
+++ b/example/ionic-angular/src/app/tab1/tab1.page.ts
@@ -135,4 +135,10 @@ export class Tab1Page {
       scope.clearBreadcrumbs();
     });
   }
+
+  public clearTestContext(): void {
+    Sentry.configureScope(scope => {
+      scope.setContext('TEST-CONTEXT', null);
+    });
+  }
 }

--- a/example/ionic-angular/src/app/tab1/tab1.page.ts
+++ b/example/ionic-angular/src/app/tab1/tab1.page.ts
@@ -129,4 +129,10 @@ export class Tab1Page {
       scope.setUser(null);
     });
   }
+
+  public clearBreadcrumbs(): void {
+    Sentry.configureScope(scope => {
+      scope.clearBreadcrumbs();
+    });
+  }
 }

--- a/example/ionic-angular/src/app/tab1/tab1.page.ts
+++ b/example/ionic-angular/src/app/tab1/tab1.page.ts
@@ -44,4 +44,89 @@ export class Tab1Page {
       new RangeError('Exception that will be ignored because of its type'),
     );
   }
+
+  public setScope(): void {
+    const dateString = new Date().toString();
+
+    Sentry.setUser({
+      id: 'test-id-0',
+      email: 'testing@testing.test',
+      username: 'USER-TEST',
+      specialField: 'special user field',
+      specialFieldNumber: 418,
+    });
+
+    Sentry.setTag('SINGLE-TAG', dateString);
+    // @ts-ignore
+    Sentry.setTag('SINGLE-TAG-NUMBER', 100);
+    Sentry.setTags({
+      'MULTI-TAG-0': dateString,
+      'MULTI-TAG-1': dateString,
+      'MULTI-TAG-2': dateString,
+    });
+
+    Sentry.setExtra('SINGLE-EXTRA', dateString);
+    Sentry.setExtra('SINGLE-EXTRA-NUMBER', 100);
+    Sentry.setExtra('SINGLE-EXTRA-OBJECT', {
+      message: 'I am a teapot',
+      status: 418,
+      array: ['boo', 100, 400, { objectInsideArray: 'foobar' }],
+    });
+    Sentry.setExtras({
+      'MULTI-EXTRA-0': dateString,
+      'MULTI-EXTRA-1': dateString,
+      'MULTI-EXTRA-2': dateString,
+    });
+
+    Sentry.setContext('TEST-CONTEXT', {
+      stringTest: 'Hello',
+      numberTest: 404,
+      objectTest: {
+        foo: 'bar',
+      },
+      arrayTest: ['foo', 'bar', 400],
+      nullTest: null,
+      undefinedTest: undefined,
+    });
+
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Info,
+      message: `TEST-BREADCRUMB-INFO: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Debug,
+      message: `TEST-BREADCRUMB-DEBUG: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Error,
+      message: `TEST-BREADCRUMB-ERROR: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Fatal,
+      message: `TEST-BREADCRUMB-FATAL: ${dateString}`,
+    });
+    Sentry.addBreadcrumb({
+      level: Sentry.Severity.Info,
+      message: `TEST-BREADCRUMB-DATA: ${dateString}`,
+      data: {
+        stringTest: 'Hello',
+        numberTest: 404,
+        objectTest: {
+          foo: 'bar',
+        },
+        arrayTest: ['foo', 'bar', 400],
+        nullTest: null,
+        undefinedTest: undefined,
+      },
+      category: 'TEST-CATEGORY',
+    });
+
+    console.log('Test scope properties were set.');
+  }
+
+  public clearUser(): void {
+    Sentry.configureScope(scope => {
+      scope.setUser(null);
+    });
+  }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -13,4 +13,5 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(setUser, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(addBreadcrumb, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(clearBreadcrumbs, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setContext, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(crash, CAPPluginReturnPromise);)

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -10,4 +10,5 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(fetchNativeSdkInfo, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setTag, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setExtra, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setUser, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(crash, CAPPluginReturnPromise);)

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -11,4 +11,6 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(setTag, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setExtra, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setUser, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(addBreadcrumb, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(clearBreadcrumbs, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(crash, CAPPluginReturnPromise);)

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -8,4 +8,6 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(captureEnvelope, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchNativeRelease, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchNativeSdkInfo, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setTag, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setExtra, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(crash, CAPPluginReturnPromise);)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -137,6 +137,32 @@ public class SentryCapacitor: CAPPlugin {
         ])
     }
 
+    @objc func setTag(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), let value = call.getString("value") else {
+            return call.reject("Error deserializing tag")
+        }
+
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: value, key: key)
+        }
+
+        call.resolve()
+    }
+
+    @objc func setExtra(_ call: CAPPluginCall) {
+        guard let key = call.getString("key") else {
+            return call.reject("Error deserializing extra")
+        }
+        
+        let value = call.getString("value")
+
+        SentrySDK.configureScope { scope in
+            scope.setExtra(value: value, key: key)
+        }
+
+        call.resolve()
+    }
+
     @objc func crash(_ call: CAPPluginCall) {
         SentrySDK.crash()
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -173,7 +173,7 @@ public class SentryCapacitor: CAPPlugin {
         }
         
         SentrySDK.configureScope { scope in
-            scope.setContext(value: call.getObject("value", [:]), key: key)
+            scope.setContext(value: call.getObject("value") ?? [:], key: key)
         }
     }
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -136,6 +136,36 @@ public class SentryCapacitor: CAPPlugin {
             "version": options.sdkInfo.version
         ])
     }
+    
+    @objc func setUser(_ call: CAPPluginCall) {
+        let defaultUserKeys = call.getObject("defaultUserKeys")
+        let otherUserKeys = call.getObject("otherUserKeys")
+        
+       
+        SentrySDK.configureScope { scope in
+            if (defaultUserKeys == nil && otherUserKeys == nil) {
+                scope.setUser(nil)
+            } else {
+                let user = User()
+                
+                
+                if let userId = defaultUserKeys?["id"] as? String {
+                    user.userId = userId
+                }
+                
+                user.email = defaultUserKeys?["email"] as! String?
+                user.username = defaultUserKeys?["username"] as! String?
+                user.ipAddress = defaultUserKeys?["ip_address"] as! String?
+                
+                user.data = otherUserKeys
+                
+                scope.setUser(user)
+            }
+        }
+        
+        
+        call.resolve()
+    }
 
     @objc func setTag(_ call: CAPPluginCall) {
         guard let key = call.getString("key"), let value = call.getString("value") else {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -226,6 +226,16 @@ public class SentryCapacitor: CAPPlugin {
         
         call.resolve()
     }
+    
+    @objc func setContext(_ call: CAPPluginCall) {
+        guard let key = call.getString("key") else {
+            return call.reject("Error deserializing context")
+        }
+        
+        SentrySDK.configureScope { scope in
+            scope.setContext(value: call.getObject("value", [:]), key: key)
+        }
+    }
 
     @objc func crash(_ call: CAPPluginCall) {
         SentrySDK.crash()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -28,10 +28,10 @@ export interface ISentryCapacitorPlugin {
   fetchNativeSdkInfo(): Promise<Package>;
   getStringBytesLength(payload: { string: string }): Promise<{ value: number }>;
   initNativeSdk(payload: { options: CapacitorOptions }): Promise<boolean>;
-  setUser(
-    user: serializedObject | null,
-    otherUserKeys: serializedObject | null,
-  ): void;
-  setTag(key: string, value: string): void;
-  setExtra(key: string, value: string): void;
+  setUser(payload: {
+    defaultUserKeys: serializedObject | null;
+    otherUserKeys: serializedObject | null;
+  }): void;
+  setTag(payload: { key: string; value: string }): void;
+  setExtra(payload: { key: string; value: string }): void;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -34,4 +34,5 @@ export interface ISentryCapacitorPlugin {
   }): void;
   setTag(payload: { key: string; value: string }): void;
   setExtra(payload: { key: string; value: string }): void;
+  setContext(payload: { key: string; value: serializedObject | null }): void;
 }

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -57,6 +57,17 @@ export class CapacitorScope extends Scope {
   /**
    * @inheritDoc
    */
+  public setContext(
+    key: string,
+    context: { [key: string]: unknown } | null,
+  ): this {
+    NATIVE.setContext(key, context);
+    return super.setContext(key, context);
+  }
+
+  /**
+   * @inheritDoc
+   */
   public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
     /* eslint-disable no-console */
     NATIVE.addBreadcrumb(breadcrumb);

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { Capacitor } from '@capacitor/core';
 import { Breadcrumb, Event, Response, Severity, User } from '@sentry/types';
-import { logger, SentryError } from '@sentry/utils';
+import { dropUndefinedKeys, logger, SentryError } from '@sentry/utils';
 
 import { CapacitorOptions } from './options';
 import { SentryCapacitor } from './plugin';
@@ -158,13 +158,15 @@ export const NATIVE = {
     let otherUserKeys = null;
     if (user) {
       const { id, ip_address, email, username, ...otherKeys } = user;
-      defaultUserKeys = this._serializeObject({
-        email,
-        id,
-        ip_address,
-        username,
-      });
-      otherUserKeys = this._serializeObject(otherKeys);
+      defaultUserKeys = dropUndefinedKeys(
+        this._serializeObject({
+          email,
+          id,
+          ip_address,
+          username,
+        }),
+      );
+      otherUserKeys = dropUndefinedKeys(this._serializeObject(otherKeys));
     }
 
     SentryCapacitor.setUser({ defaultUserKeys, otherUserKeys });

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -216,7 +216,7 @@ export const NATIVE = {
    * @param breadcrumb Breadcrumb
    */
   addBreadcrumb(breadcrumb: Breadcrumb): void {
-    if (!this.enableNative || this.platform === 'ios') {
+    if (!this.enableNative) {
       return;
     }
     if (!this.isNativeClientAvailable()) {
@@ -239,7 +239,7 @@ export const NATIVE = {
    * Clears breadcrumbs on the native scope.
    */
   clearBreadcrumbs(): void {
-    if (!this.enableNative || this.platform === 'ios') {
+    if (!this.enableNative) {
       return;
     }
     if (!this.isNativeClientAvailable()) {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -146,7 +146,7 @@ export const NATIVE = {
    * @param value string
    */
   setUser(user: User | null): void {
-    if (!this.enableNative || this.platform === 'ios') {
+    if (!this.enableNative) {
       return;
     }
     if (!this.isNativeClientAvailable()) {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -167,7 +167,7 @@ export const NATIVE = {
       otherUserKeys = this._serializeObject(otherKeys);
     }
 
-    SentryCapacitor.setUser(defaultUserKeys, otherUserKeys);
+    SentryCapacitor.setUser({ defaultUserKeys, otherUserKeys });
   },
 
   /**
@@ -176,7 +176,7 @@ export const NATIVE = {
    * @param value string
    */
   setTag(key: string, value: string): void {
-    if (!this.enableNative || this.platform === 'ios') {
+    if (!this.enableNative) {
       return;
     }
     if (!this.isNativeClientAvailable()) {
@@ -186,7 +186,7 @@ export const NATIVE = {
     const stringifiedValue =
       typeof value === 'string' ? value : JSON.stringify(value);
 
-    SentryCapacitor.setTag(key, stringifiedValue);
+    SentryCapacitor.setTag({ key, value: stringifiedValue });
   },
 
   /**
@@ -196,7 +196,7 @@ export const NATIVE = {
    * @param extra any
    */
   setExtra(key: string, extra: unknown): void {
-    if (!this.enableNative || this.platform === 'ios') {
+    if (!this.enableNative) {
       return;
     }
     if (!this.isNativeClientAvailable()) {
@@ -204,11 +204,11 @@ export const NATIVE = {
     }
 
     // we stringify the extra as native only takes in strings.
-    const stringifiedExtra =
+    const stringifiedValue =
       typeof extra === 'string' ? extra : JSON.stringify(extra);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    SentryCapacitor.setExtra(key, stringifiedExtra);
+    SentryCapacitor.setExtra({ key, value: stringifiedValue });
   },
 
   /**

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -250,6 +250,31 @@ export const NATIVE = {
   },
 
   /**
+   * Sets context on the native scope. Not implemented in Android yet.
+   * @param key string
+   * @param context key-value map
+   */
+  setContext(key: string, context: { [key: string]: unknown } | null): void {
+    if (!this.enableNative) {
+      return;
+    }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    if (this.platform === 'android') {
+      // setContext not available on the Android SDK yet.
+      this.setExtra(key, context);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      SentryCapacitor.setContext({
+        key,
+        value: context !== null ? this._serializeObject(context) : null,
+      });
+    }
+  },
+
+  /**
    * Serializes all values of root-level keys into strings.
    * @param data key-value map.
    * @returns An object where all root-level values are strings.

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -35,11 +35,18 @@ jest.mock('../src/plugin', () => {
           version: '0.0.1',
         }),
       ),
-      getStringBytesLength: jest.fn(() => Promise.resolve({ value: 1 })),
+      getStringBytesLength: jest.fn(() =>
+        Promise.resolve({
+          value: 1,
+        }),
+      ),
+      initNativeSdk: jest.fn(options => Promise.resolve(options)),
+      setContext: jest.fn(() => Promise.resolve()),
+      setExtra: jest.fn(() => Promise.resolve()),
+      setTag: jest.fn(() => Promise.resolve()),
       setUser: jest.fn(() => {
         return;
       }),
-      initNativeSdk: jest.fn(options => Promise.resolve(options)),
     },
   };
 });
@@ -48,6 +55,7 @@ import { SentryCapacitor } from '../src/plugin';
 
 beforeEach(() => {
   NATIVE.enableNative = true;
+  NATIVE.platform = 'android';
 });
 
 afterEach(() => {
@@ -199,6 +207,83 @@ describe('Tests Native Wrapper', () => {
           id: 'Hello',
         },
         otherUserKeys: {},
+      });
+    });
+  });
+
+  describe('setTag', () => {
+    it('calls setTag', () => {
+      NATIVE.setTag('key', 'value');
+
+      expect(SentryCapacitor.setTag).toBeCalledWith({
+        key: 'key',
+        value: 'value',
+      });
+    });
+
+    it('serializes number', () => {
+      // @ts-ignore test number
+      NATIVE.setTag('key', 0);
+
+      expect(SentryCapacitor.setTag).toBeCalledWith({
+        key: 'key',
+        value: '0',
+      });
+    });
+
+    it('serializes object', () => {
+      // @ts-ignore test number
+      NATIVE.setTag('key', {});
+
+      expect(SentryCapacitor.setTag).toBeCalledWith({
+        key: 'key',
+        value: '{}',
+      });
+    });
+  });
+
+  describe('setExtra', () => {
+    it('calls setExtra', () => {
+      NATIVE.setExtra('key', { hello: 'world' });
+
+      expect(SentryCapacitor.setExtra).toBeCalledWith({
+        key: 'key',
+        value: '{"hello":"world"}',
+      });
+    });
+  });
+
+  describe('setContext', () => {
+    it('calls setContext', () => {
+      NATIVE.platform = 'ios';
+
+      NATIVE.setContext('key', { hello: 'world' });
+
+      expect(SentryCapacitor.setContext).toBeCalledWith({
+        key: 'key',
+        value: { hello: 'world' },
+      });
+    });
+
+    it('calls setContext with null', () => {
+      NATIVE.platform = 'ios';
+
+      NATIVE.setContext('key', null);
+
+      expect(SentryCapacitor.setContext).toBeCalledWith({
+        key: 'key',
+        value: null,
+      });
+    });
+
+    it('calls setExtra on android', () => {
+      NATIVE.platform = 'android';
+
+      NATIVE.setContext('key', { hello: 'world' });
+
+      expect(SentryCapacitor.setExtra).toBeCalledWith({
+        key: 'key',
+        value: '{"hello":"world"}',
       });
     });
   });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -178,15 +178,15 @@ describe('Tests Native Wrapper', () => {
         unique: '123',
       });
 
-      expect(SentryCapacitor.setUser).toBeCalledWith(
-        {
+      expect(SentryCapacitor.setUser).toBeCalledWith({
+        defaultUserKeys: {
           email: 'hello@sentry.io',
           id: '3.1234587',
         },
-        {
+        otherUserKeys: {
           unique: '123',
         },
-      );
+      });
     });
 
     test('calls native setUser with empty object as second param if no unique keys', async () => {
@@ -194,12 +194,12 @@ describe('Tests Native Wrapper', () => {
         id: 'Hello',
       });
 
-      expect(SentryCapacitor.setUser).toBeCalledWith(
-        {
+      expect(SentryCapacitor.setUser).toBeCalledWith({
+        defaultUserKeys: {
           id: 'Hello',
         },
-        {},
-      );
+        otherUserKeys: {},
+      });
     });
   });
 


### PR DESCRIPTION
Add scope sync methods for `setTag`, `setExtra`, `setUser`, `addBreadcrumb`, `clearBreadcrumb` for iOS. 

Fixes `setUser` not taking non-default data and `clearBreadcrumbs` on Android.

Adds test for the JS side of the bridge, and methods to test scope sync on the sample apps.

Tested on the v3 sample app.