### PR TITLE
await for getStringBytesLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Use Native length for Envelopes when available #128
+
 ## 0.4.2
 
 - No longer export deprecated Status enum #111

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -40,7 +40,7 @@ export const NATIVE = {
     const payloadString: string = JSON.stringify(payload);
     let length = payloadString.length;
     try {
-      void SentryCapacitor.getStringBytesLength({ string: payloadString }).then(
+      await SentryCapacitor.getStringBytesLength({ string: payloadString }).then(
         resp => {
           length = resp.value;
         },

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -4,6 +4,8 @@ import { logger } from '@sentry/utils';
 
 import { NATIVE } from '../src/wrapper';
 
+let getStringBytesLengthValue = 1;
+
 jest.mock(
   '@capacitor/core',
   () => {
@@ -37,7 +39,7 @@ jest.mock('../src/plugin', () => {
       ),
       getStringBytesLength: jest.fn(() =>
         Promise.resolve({
-          value: 1,
+          value: getStringBytesLengthValue,
         }),
       ),
       initNativeSdk: jest.fn(options => Promise.resolve(options)),
@@ -54,6 +56,7 @@ jest.mock('../src/plugin', () => {
 import { SentryCapacitor } from '../src/plugin';
 
 beforeEach(() => {
+  getStringBytesLengthValue = 1;
   NATIVE.enableNative = true;
   NATIVE.platform = 'android';
 });
@@ -105,9 +108,12 @@ describe('Tests Native Wrapper', () => {
 
   describe('sendEvent', () => {
     test('calls getStringBytesLength and captureEnvelope', async () => {
+      const expectedNativeLength = 101;
+      getStringBytesLengthValue = expectedNativeLength;
+
       const event = {
         event_id: 'event0',
-        message: 'test',
+        message: 'test©',
         sdk: {
           name: 'test-sdk-name',
           version: '1.2.3',
@@ -128,7 +134,7 @@ describe('Tests Native Wrapper', () => {
 
       const item = JSON.stringify({
         content_type: 'application/json',
-        length: 99,
+        length: expectedNativeLength,
         type: 'event',
       });
 


### PR DESCRIPTION
Because of that, the Length was being set with the size of the string, which resulted in ok behaviors if the serialized string was in UTF-8, but if someone decided to add an UTF-16/32 character, would result on the wrong length of the envelope.

This PR awaits for getStringBytesLength to be conclude and sets the length with the value from the native callback.

Close #124