### PR TITLE
remove sdkProcessingMetadata from native events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- remove sdkProcessingMetadata from native events ([#139](https://github.com/getsentry/sentry-capacitor/pull/139))
+
 ## 0.4.3
 
 ### Fixes

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -24,6 +24,9 @@ export const NATIVE = {
 
     const event = this._processLevels(_event);
 
+    // Delete this metadata as this should not be sent to Sentry.
+    delete event.sdkProcessingMetadata;
+
     const header = {
       event_id: event.event_id,
       sdk: event.sdk,

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -28,7 +28,9 @@ jest.mock('../src/plugin', () => {
   return {
     SentryCapacitor: {
       addBreadcrumb: jest.fn(),
-      captureEnvelope: jest.fn(envelope => Promise.resolve(envelope)),
+      captureEnvelope: jest.fn(envelope => {
+        return Promise.resolve(envelope);
+      }),
       crash: jest.fn(),
       fetchNativeRelease: jest.fn(() =>
         Promise.resolve({
@@ -155,6 +157,26 @@ describe('Tests Native Wrapper', () => {
 
       expect(SentryCapacitor.getStringBytesLength).not.toBeCalled();
       expect(SentryCapacitor.captureEnvelope).not.toBeCalled();
+    });
+
+    test('does not include sdkProcessingMetadata on event sent', async () => {
+      const event = {
+        event_id: 'event0',
+        message: 'test©',
+        sdk: {
+          name: 'test-sdk-name',
+          version: '1.2.3',
+        },
+        sdkProcessingMetadata: ["uneeeded data.", "xz"]
+      };
+      const captureEnvelopeSpy = jest.spyOn(SentryCapacitor, 'captureEnvelope');
+
+      await NATIVE.initNativeSdk({ dsn: 'test-dsn', enableNative: true });
+      await NATIVE.sendEvent(event);
+
+      expect(SentryCapacitor.captureEnvelope).toBeCalledTimes(1);
+      expect(captureEnvelopeSpy.mock.calls[0][0].envelope).toContain(event.event_id);
+      expect(captureEnvelopeSpy.mock.calls[0][0].envelope).not.toContain('sdkProcessingMetadata');
     });
   });
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -28,9 +28,7 @@ jest.mock('../src/plugin', () => {
   return {
     SentryCapacitor: {
       addBreadcrumb: jest.fn(),
-      captureEnvelope: jest.fn(envelope => {
-        return Promise.resolve(envelope);
-      }),
+      captureEnvelope: jest.fn(envelope => Promise.resolve(envelope)),
       crash: jest.fn(),
       fetchNativeRelease: jest.fn(() =>
         Promise.resolve({


### PR DESCRIPTION
This parameter is only used on the Javascript side of the SDK and shouldn't be sent to the Native event handler.

Closes #125.