### PR TITLE
Add missing setup information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ You need:
 - yarn 1 or higher
 - yalc
 - http-server
+- ionic
 
 ## Building
 

--- a/example/ionic-angular-v2/README.md
+++ b/example/ionic-angular-v2/README.md
@@ -2,6 +2,10 @@
 
 ## Add the local SDK from yalc
 
+On the Sentry Capacitor root folder
+`yalc publish`
+
+Then on the ionic-angular-v2 folder
 `yalc add @sentry/capacitor`
 
 ## Install dependencies

--- a/example/ionic-angular/README.md
+++ b/example/ionic-angular/README.md
@@ -2,6 +2,10 @@
 
 ## Add the local SDK from yalc
 
+On the Sentry Capacitor root folder
+`yalc publish`
+
+Then on the ionic-angular folder
 `yalc add @sentry/capacitor`
 
 ## Install dependencies


### PR DESCRIPTION
just some quality of life information that will help folks to setup Sentry-Capacitor and the included examples.

#skip-changelog.