### PR TITLE
Add Missing config `enableOutOfMemoryTracking` for iOS/Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- (iOS) Missing config `enableOutOfMemoryTracking` on iOS/Mac
+- (iOS) Missing config `enableOutOfMemoryTracking` on iOS/Mac ([#147](https://github.com/getsentry/sentry-capacitor/pull/147))
 
 ## 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- (iOS) Missing config `enableOutOfMemoryTracking` on iOS/Mac
+
 ## 0.4.4
 
 ### Fixes

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,4 +35,14 @@ export interface CapacitorOptions
 
   /** When enabled, all the threads are automatically attached to all logged events on Android */
   attachThreads?: boolean;
+
+  /**
+  * Enables Out of Memory Tracking for iOS and macCatalyst.
+  * See the following link for more information and possible restrictions:
+  * https://docs.sentry.io/platforms/apple/guides/ios/configuration/out-of-memory/
+  *
+  * @default true
+  * */
+  enableOutOfMemoryTracking?: boolean;
+
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -23,6 +23,7 @@ export function init<O>(
 ): void {
   const finalOptions = {
     enableAutoSessionTracking: true,
+    enableOutOfMemoryTracking: true,
     ...options,
   };
 


### PR DESCRIPTION
Add an option filter to avoid registering out of error events if the user doesn't want it.

Partially solves #127