### PR TITLE
Fix iOS dropping envelopes with UTF16 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix iOS dropping events if envelope contains UTF16 character or higher
+
 ## 0.4.4
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix iOS dropping events if envelope contains UTF16 character or higher
+- Fix iOS dropping events if envelope contains UTF16 character or higher ([#150](https://github.com/getsentry/sentry-capacitor/pull/150))
 
 ## 0.4.4
 

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -8,6 +8,7 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(captureEnvelope, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchNativeRelease, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchNativeSdkInfo, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getStringBytesLength, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setTag, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setExtra, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setUser, CAPPluginReturnPromise);


### PR DESCRIPTION
Not sure how but, getStringBytesLength was missing from iOS so I just implemented it

Fixes #124 and #100

Tested event: https://sentry.io/organizations/sentry-sdks/discover/sentry-capacitor:b7e9eb1c22f34d1b84f0b085db3a733a/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5522756&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29