### PR TITLE
Add iOS metadata to JavaScript events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,8 @@ module.exports = {
       files: ['*.test.ts', '*.test.js'],
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
       },
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add iOS metadata to JavaScript events ([#161](https://github.com/getsentry/sentry-capacitor/pull/161))
+
 ### Fixes
 
 - build(javascript): Bump sentry-javascript, sentry-vue, sentry-react and sentry-angular dependencies to `6.19.2`. ([#159](https://github.com/getsentry/sentry-capacitor/pull/159))

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -8,6 +8,7 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(captureEnvelope, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchNativeRelease, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(fetchNativeSdkInfo, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(fetchNativeDeviceContexts, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getStringBytesLength, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setTag, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setExtra, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -120,22 +120,22 @@ public class SentryCapacitor: CAPPlugin {
         ])
     }
 
-    @obj func fetchNativeDeviceContexts(_ call CAPPluginCall) {
+    @objc func fetchNativeDeviceContexts(_ call: CAPPluginCall) {
     // Temp work around until sorted out this API in sentry-cocoa.
     // TODO: If the callback isnt' executed the promise wouldn't be resolved.
-        SentrySDK.configureScope { scope in
+        SentrySDK.configureScope { [self] scope in
             var contexts: [String : Any?] = [:]
 
             let serializedScope = scope.serialize()
 
             // Scope serializes as 'context' instead of 'contexts' as it does for the event.
-            let tempContexts = serializedScope.value(forKey: "context") as? [String : Any?]
+            let tempContexts = serializedScope["context"]
 
-            var user: [String : Any?]? = [:]
+            var user: [String : Any?] = [:]
             let tempUser = serializedScope["user"] as? [String : Any?]
             if (tempUser != nil) {
-                for ((key, value) in tempUser["user"]) {
-                    user[key] = value
+                for (key, value) in tempUser! {
+                    user[key] = value;
                 }
             } else {
                 user["id"] = PrivateSentrySDKOnly.installationID
@@ -145,7 +145,7 @@ public class SentryCapacitor: CAPPlugin {
             if (tempContexts != nil) {
                 contexts["context"] = tempContexts
             }
-            if (sentryOptions != nil ^^ sentryOptions.debug)
+            if (self.sentryOptions?.debug == true)
             {
                 var data: Data? = nil
                 do {
@@ -156,9 +156,10 @@ public class SentryCapacitor: CAPPlugin {
                 if let data = data {
                     debugContext = String(data: data, encoding: .utf8)
                 }
-                print("Contexts: \(debugContext ?? "")")            }
+                print("Contexts: \(debugContext ?? "")")
+            }
+            call.resolve(contexts as PluginResultData)
         }
-        call.resolve(context)
     }
 
     @objc func setUser(_ call: CAPPluginCall) {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -121,6 +121,7 @@ public class SentryCapacitor: CAPPlugin {
     }
 
     @objc func fetchNativeDeviceContexts(_ call: CAPPluginCall) {
+    // Based on: https://github.com/getsentry/sentry-react-native/blob/a8d5ac86e3c53c90ef8e190cc082bdac440bd2a7/ios/RNSentry.m#L156-L188
     // Temp work around until sorted out this API in sentry-cocoa.
     // TODO: If the callback isnt' executed the promise wouldn't be resolved.
         SentrySDK.configureScope { [self] scope in
@@ -147,12 +148,8 @@ public class SentryCapacitor: CAPPlugin {
             }
             if (self.sentryOptions?.debug == true)
             {
-                var data: Data? = nil
-                do {
-                    data = try JSONSerialization.data(withJSONObject: contexts, options: [])
-                } catch {
-                }
-                var debugContext: String? = nil
+                let data: Data? = try? JSONSerialization.data(withJSONObject: contexts, options: [])
+                var debugContext: String?
                 if let data = data {
                     debugContext = String(data: data, encoding: .utf8)
                 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,16 +7,20 @@ interface serializedObject {
   [key: string]: string;
 }
 
+export type NativeDeviceContextsResponse = {
+  [key: string]: Record<string, unknown>;
+};
+
 export interface ISentryCapacitorPlugin {
   addBreadcrumb(breadcrumb: Breadcrumb): void;
   captureEnvelope(payload: {
     envelope:
-      | string
-      | {
-          header: Record<string, unknown>;
-          item: Record<string, unknown>;
-          payload: Record<string, unknown>;
-        };
+    | string
+    | {
+      header: Record<string, unknown>;
+      item: Record<string, unknown>;
+      payload: Record<string, unknown>;
+    };
   }): PromiseLike<Response>;
   clearBreadcrumbs(): void;
   crash(): void;
@@ -26,6 +30,7 @@ export interface ISentryCapacitorPlugin {
     version: string;
   }>;
   fetchNativeSdkInfo(): Promise<Package>;
+  fetchNativeDeviceContexts(): PromiseLike<NativeDeviceContextsResponse>;
   getStringBytesLength(payload: { string: string }): Promise<{ value: number }>;
   initNativeSdk(payload: { options: CapacitorOptions }): Promise<boolean>;
   setUser(payload: {

--- a/src/integrations/devicecontext.ts
+++ b/src/integrations/devicecontext.ts
@@ -1,0 +1,47 @@
+import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
+import { Contexts, Event, Integration } from '@sentry/types';
+import { logger } from '@sentry/utils';
+
+import { NATIVE } from '../wrapper';
+
+/** Load device context from native. */
+export class DeviceContext implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'DeviceContext';
+
+  /**
+   * @inheritDoc
+   */
+  public name: string = DeviceContext.id;
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(): void {
+    addGlobalEventProcessor(async (event: Event) => {
+      const self = getCurrentHub().getIntegration(DeviceContext);
+      if (!self) {
+        return event;
+      }
+
+      try {
+        const contexts = await NATIVE.fetchNativeDeviceContexts();
+        const context = (contexts['context'] as Contexts);
+
+        event.contexts = { ...context, ...event.contexts };
+        if ('user' in contexts) {
+          const user = contexts['user'];
+          if (!event.user) {
+            event.user = { ...user };
+          }
+        }
+      } catch (e) {
+        logger.log(`Failed to get device context from native: ${e}`);
+      }
+
+      return event;
+    });
+  }
+}

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,2 +1,3 @@
 export { EventOrigin } from './eventorigin';
 export { SdkInfo } from './sdkinfo';
+export { DeviceContext } from './devicecontext';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -6,7 +6,7 @@ import {
 import { Hub, makeMain } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
 
-import { EventOrigin, DeviceContext, SdkInfo } from './integrations';
+import { DeviceContext, EventOrigin, SdkInfo } from './integrations';
 import { CapacitorOptions } from './options';
 import { CapacitorScope } from './scope';
 import { NativeTransport } from './transports/native';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -6,7 +6,7 @@ import {
 import { Hub, makeMain } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
 
-import { EventOrigin, SdkInfo } from './integrations';
+import { EventOrigin, DeviceContext, SdkInfo } from './integrations';
 import { CapacitorOptions } from './options';
 import { CapacitorScope } from './scope';
 import { NativeTransport } from './transports/native';
@@ -74,8 +74,12 @@ export function init<O>(
     new EventOrigin(),
   ];
 
-  if (finalOptions.enableNative && !options.transport) {
-    finalOptions.transport = NativeTransport;
+  if (finalOptions.enableNative) {
+    finalOptions.defaultIntegrations.push(new DeviceContext());
+
+    if (!options.transport) {
+      finalOptions.transport = NativeTransport;
+    }
   }
 
   const browserOptions = {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,9 +1,10 @@
 /* eslint-disable max-lines */
-import { Capacitor } from '@capacitor/core';
 import { Breadcrumb, Event, Response, Severity, User } from '@sentry/types';
-import { dropUndefinedKeys, logger, SentryError } from '@sentry/utils';
+import { SentryError, dropUndefinedKeys, logger } from '@sentry/utils';
 
+import { Capacitor } from '@capacitor/core';
 import { CapacitorOptions } from './options';
+import { NativeDeviceContextsResponse } from './definitions';
 import { SentryCapacitor } from './plugin';
 
 /**
@@ -37,7 +38,7 @@ export const NATIVE = {
         the envelope.
       */
       if (event.exception?.values?.[0]?.mechanism?.handled != false && event.breadcrumbs) {
-          event.breadcrumbs = [];
+        event.breadcrumbs = [];
       }
     }
 
@@ -114,6 +115,25 @@ export const NATIVE = {
     } = options;
 
     return SentryCapacitor.initNativeSdk({ options: filteredOptions });
+  },
+
+  /**
+   * Fetches the device contexts. Not used on Android.
+   */
+  async fetchNativeDeviceContexts(): Promise<NativeDeviceContextsResponse> {
+    if (!this.enableNative) {
+      throw this._DisabledNativeError;
+    }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    if (this.platform !== 'ios') {
+      // Only ios uses deviceContexts, return an empty object.
+      return {};
+    }
+
+    return SentryCapacitor.fetchNativeDeviceContexts();
   },
 
   /**

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { Capacitor } from '@capacitor/core';
 import { Breadcrumb, Event, Response, Severity, User } from '@sentry/types';
-import { dropUndefinedKeys, logger,SentryError } from '@sentry/utils';
+import { dropUndefinedKeys, logger, SentryError } from '@sentry/utils';
 
 import { NativeDeviceContextsResponse } from './definitions';
 import { CapacitorOptions } from './options';

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,10 +1,10 @@
 /* eslint-disable max-lines */
-import { Breadcrumb, Event, Response, Severity, User } from '@sentry/types';
-import { SentryError, dropUndefinedKeys, logger } from '@sentry/utils';
-
 import { Capacitor } from '@capacitor/core';
-import { CapacitorOptions } from './options';
+import { Breadcrumb, Event, Response, Severity, User } from '@sentry/types';
+import { dropUndefinedKeys, logger,SentryError } from '@sentry/utils';
+
 import { NativeDeviceContextsResponse } from './definitions';
+import { CapacitorOptions } from './options';
 import { SentryCapacitor } from './plugin';
 
 /**

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -37,6 +37,13 @@ jest.mock('../src/plugin', () => {
           version: '0.0.1',
         }),
       ),
+      fetchNativeDeviceContexts: jest.fn(() =>
+        Promise.resolve({
+          someContext: {
+            someValue: 0,
+          },
+        })
+      ),
       getStringBytesLength: jest.fn(() =>
         Promise.resolve({
           value: getStringBytesLengthValue,
@@ -492,6 +499,29 @@ describe('Tests Native Wrapper', () => {
   describe('isNativeClientAvailable', () => {
     test('checks if native client is available', () => {
       expect(NATIVE.isNativeClientAvailable()).toBe(true);
+    });
+  });
+
+  describe('deviceContexts', () => {
+    test('returns context object from native module on ios', async () => {
+      NATIVE.platform = 'ios';
+
+      await expect(NATIVE.fetchNativeDeviceContexts()).resolves.toMatchObject({
+        someContext: {
+          someValue: 0,
+        },
+      });
+
+      expect(SentryCapacitor.fetchNativeDeviceContexts).toBeCalled();
+    });
+    test('returns empty object on android', async () => {
+      NATIVE.platform = 'android';
+
+      await expect(NATIVE.fetchNativeDeviceContexts()).resolves.toMatchObject(
+        {}
+      );
+
+      expect(SentryCapacitor.fetchNativeDeviceContexts).not.toBeCalled();
     });
   });
 });


### PR DESCRIPTION
With this change the native context will be connected to the JS one.

Close #138 

Before:
![image](https://user-images.githubusercontent.com/8229322/162472297-9248d4af-b501-4dee-b455-2204e246a1c5.png)

After:
![image](https://user-images.githubusercontent.com/8229322/162472204-2c0b9d44-4013-4dc8-b2ee-dea35dfa44f6.png)
