### PR TITLE
Fix Stack Trace when using localhost

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -45,13 +45,14 @@ export function init<O>(
     new RewriteFrames({
       iteratee: (frame: StackFrame) => {
         if (frame.filename) {
+          const isReachableHost = /^https?:\/\//.test(frame.filename);
+
           frame.filename = frame.filename
-            .replace(/^https?:\/\/localhost/, '')
+            .replace(/^https?:\/\/localhost(:\d+)?/, '')
             .replace(/^ng:\/\//, '')
-            .replace(/^capacitor:\/\/localhost/, '');
+            .replace(/^capacitor:\/\/localhost(:\d+)?/, '');
 
           const isNativeFrame = frame.filename === '[native code]' || frame.filename === 'native';
-          const isReachableHost = /^https?:\/\//.test(frame.filename);
 
           if (!isNativeFrame) {
             // We don't need to use `app://` protocol for http(s) based hosts


### PR DESCRIPTION
This PR fixes the following cases found on #90

* localhost with port number was incorrectly parsed. (http://localhost:8080/)
* localhost addresses became app:/// ... not allowing the correct source map to be applied (http://localhost/test.js became app:///test.js instead of /test.js)

Additionally, extra tests were added to the StackTrace parser.

With the following changes, users will be able to get the correct source map when accessing their apps on the browser from  localhost with and without a port, but also by specifying the local ip address from the host machine.