### PR TITLE
Android: Fix java.lang.IllegalArgumentException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- SentryCapacitor.crash not working on Android ([#175](https://github.com/getsentry/sentry-capacitor/pull/175))
+
 ## 0.6.1
 
 ### Fixes

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -188,7 +188,7 @@ public class SentryCapacitor extends Plugin {
     }
 
     @PluginMethod
-    public void crash() {
+    public void crash(PluginCall call) {
         throw new RuntimeException("TEST - Sentry Client Crash (only works in release mode)");
     }
 


### PR DESCRIPTION
When invoking `Sentry.nativeCrash`, plugin crashes with following logcat output:

```
E/Capacitor: Serious error executing plugin
    java.lang.IllegalArgumentException: Wrong number of arguments; expected 0, got 1
        at java.lang.reflect.Method.invoke(Native Method)
        at com.getcapacitor.PluginHandle.invoke(PluginHandle.java:121)
        at com.getcapacitor.Bridge.lambda$callPluginMethod$0$Bridge(Bridge.java:598)
        at com.getcapacitor.-$$Lambda$Bridge$25SFHybyAQk7zS27hTVXh2p8tmw.run(Unknown Source:8)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```

Instead of `java.lang.RuntimeException: TEST - Sentry Client Crash (only works in release mode)`

Every Capacitor method expects at least one argument (`PluginCall call`), which is missing. This PR solves method signature.

References:
- Capacitor docs > Creating Plugins > Development Workflow > [Implementing a New Method](https://capacitorjs.com/docs/plugins/workflow#implementing-a-new-method)
- @capacitor/app -> [exitApp method](https://github.com/ionic-team/capacitor-plugins/blob/%40capacitor/toast%401.0.8/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java#L62)

Output after changes:

```
E/Capacitor: Serious error executing plugin
    java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Method.invoke(Native Method)
        at com.getcapacitor.PluginHandle.invoke(PluginHandle.java:121)
        at com.getcapacitor.Bridge.lambda$callPluginMethod$0$Bridge(Bridge.java:598)
        at com.getcapacitor.-$$Lambda$Bridge$25SFHybyAQk7zS27hTVXh2p8tmw.run(Unknown Source:8)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.os.HandlerThread.run(HandlerThread.java:67)
     Caused by: java.lang.RuntimeException: TEST - Sentry Client Crash (only works in release mode)
        at io.sentry.capacitor.SentryCapacitor.crash(SentryCapacitor.java:192)
```