### PR TITLE
iOS: Replace deprecated PluginResultData

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -155,7 +155,7 @@ public class SentryCapacitor: CAPPlugin {
                 }
                 print("Contexts: \(debugContext ?? "")")
             }
-            call.resolve(contexts as PluginResultData)
+            call.resolve(contexts as PluginCallResultData)
         }
     }
 


### PR DESCRIPTION
PluginResultData has deprecated in favor of PluginCallResultData in Capacitor 3 (see https://github.com/ionic-team/capacitor/blob/3.5.1/ios/Capacitor/Capacitor/CAPPluginCall.swift#L3)

This package requires @capacitor/core@3 since it's 0.2.1 version

Fixes one issue of https://github.com/getsentry/sentry-capacitor/issues/176