### PR TITLE
iOS: Avoid warning by force-unwrapping value

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -92,7 +92,7 @@ public class SentryCapacitor: CAPPlugin {
     @objc func getStringBytesLength(_ call: CAPPluginCall) {
         let payloadSize = call.getString("string")?.utf8.count
         if (payloadSize != nil) {
-            call.resolve(["value": payloadSize])
+            call.resolve(["value": payloadSize!])
         }
         else {
             call.reject("Coud not calculate string length.")


### PR DESCRIPTION
Fixes first issue of https://github.com/getsentry/sentry-capacitor/issues/176.

I have no experience with swift, but since the `payloadSize` is being tested against `nil`, it should be safe for force Int

#skip-changelog.