### PR TITLE
Add support for Capacitor 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add support for Capacitor 4.0.0 ([#201](https://github.com/getsentry/sentry-capacitor/pull/201))
+
 ## 0.8.0
 
 ### Features

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.dependency 'Sentry', '~> 7.11.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -11,7 +11,14 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '13.0'
+  capacitorPackage =  JSON.parse(File.read(File.join(__dir__, '../../@capacitor/core/package.json')))
+  capacitorVersion = capacitorPackage['version']
+  if capacitorVersion.start_with?("2.") or capacitorVersion.start_with?("3.")
+    miniOSVersion = '12.0'
+  else
+    miniOSVersion = '13.0' # Required for Capacitor 4 and newer.
+  end
+  s.ios.deployment_target  = miniOSVersion
   s.dependency 'Sentry', '~> 7.11.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,17 +10,17 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 29
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 29
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.google.gms:google-services:4.3.13'
     }
 }
 
@@ -35,8 +36,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_11
     }
     buildToolsVersion '29.0.3'
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../node_modules/@capacitor/ios/scripts/pods_helpers'
+
 platform :ios, '13.0'
 
 def capacitor_pods
@@ -15,4 +17,8 @@ end
 
 target 'PluginTests' do
   capacitor_pods
+end
+
+post_install do |installer|
+  assertDeploymentTarget(installer)
 end

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "promise": "^8.1.0"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.1",
-    "@capacitor/core": "^3.0.1",
-    "@capacitor/ios": "^3.0.1",
+    "@capacitor/android": "^3.0.1 || ^4.0.0",
+    "@capacitor/core": "^3.0.1 || ^4.0.0",
+    "@capacitor/ios": "^3.0.1 || ^4.0.0",
     "@ionic/prettier-config": "^1.0.0",
     "@sentry-internal/eslint-config-sdk": "7.6.0",
     "@sentry-internal/eslint-plugin-sdk": "7.6.0",


### PR DESCRIPTION
capacitor 4.0.0 deployed! ([release](https://github.com/ionic-team/capacitor/releases))

so fixes `error: compiling for iOS 12.0, but module 'Capacitor' has a minimum deployment target of iOS 13.0` 