### PR TITLE
Update yarn lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -596,13 +596,13 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@sentry-internal/eslint-config-sdk@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.6.0.tgz#65c785279884d9071649cf16925ada148fed5b80"
-  integrity sha512-9uMBCmfIu7qFV4XHoqENhckuZg+n8eeUKa5KKeFaTjbtni9RSyRb5KnRc81ifYd8vQO08DQbXdUFuWTC3WSSxA==
+"@sentry-internal/eslint-config-sdk@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.8.1.tgz#e26d8721cfd289591a9fb4c864c9655956d31118"
+  integrity sha512-p1n/KZw1usK4dONInADFgVMG5Jb2fhSnwDfUzx2EG2rUClTFataoRb53girY/8z1RZrh92dhtQVHElS9sdz/iQ==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.6.0"
-    "@sentry-internal/typescript" "7.6.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.8.1"
+    "@sentry-internal/typescript" "7.8.1"
     "@typescript-eslint/eslint-plugin" "^3.9.0"
     "@typescript-eslint/parser" "^3.9.0"
     eslint-config-prettier "^6.11.0"
@@ -611,26 +611,26 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.6.0.tgz#00c0975677635cc61f7eff9d4b81b87e10be97a3"
-  integrity sha512-j06/hXd9Q+E4SMgFYJRF+CephY3gnU/eWveIlale/D2SJ57AdzLyZuaQX1FTDI30KCAGl2Tj5ibqEupbxTDrXA==
+"@sentry-internal/eslint-plugin-sdk@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.8.1.tgz#01df570c17bc57efb126aba7635b3da2da4e3087"
+  integrity sha512-w0o7MkHixrLsCvcKiXejqY/TbsYFrzYBIRvX9zj60Wn3corjC/jNB0VC5CmXrsI71O6B1zvkw2gKfVYDdQ7Dug==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.6.0.tgz#e43349c1d685b3517f58e9df593c6b158d116464"
-  integrity sha512-7wxCkYGZvkpssPizzWPAoZQky93efcq9+aC1J4qJUtYpTDCwGkED+tlmAJKZULqZeKKaRWDGaO8s84q5Cx0aGg==
+"@sentry-internal/typescript@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.8.1.tgz#886e446b3a8fc54f52e84824ab16fd6b839d489e"
+  integrity sha512-3newTQXCuM4/rt51lo/ASd0+/dksi6wSmQt42914rfQf4dMxAwNeKyf3k6stcar1RdQQXXGv0lZfbtDOQ0wvzA==
 
-"@sentry/browser@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.6.0.tgz#54bcd52747c40b2656d62d53541037a5724f3296"
-  integrity sha512-1gdvV8RtTnNFyc790t49MAgFuHAP43NEZvdQOMw5KFnDwSGYFqfBtvJ8tUm125UPbi2fghBryO9M1gfIWboKUg==
+"@sentry/browser@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.8.1.tgz#ca91c80a5da745e1b5379bc215100ba4660bac29"
+  integrity sha512-9JuagYqHyaZu/4RqyxrAgEHo71oV592XBuUKC33gajCVKWbyG3mNqudSMoHtdM1DrV9REZ4Elha7zFaE2cJX6g==
   dependencies:
-    "@sentry/core" "7.6.0"
-    "@sentry/types" "7.6.0"
-    "@sentry/utils" "7.6.0"
+    "@sentry/core" "7.8.1"
+    "@sentry/types" "7.8.1"
+    "@sentry/utils" "7.8.1"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.52.4":
@@ -644,23 +644,14 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.6.0.tgz#5e5efd54af7b63957ac4d446fb5a69af33da3e51"
-  integrity sha512-vXIuUZbHVSAXh2xZ3NyXYXqVvVQSbGEpgtQxLutwocvD88JFK6aZqO+WQG69GY1b1fKSeE9faEDDS6WGAi46mQ==
+"@sentry/core@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.8.1.tgz#d11ba7c97766d1e47edf697dbfd47fe4041477d9"
+  integrity sha512-PRivbdIzApi/gSixAxozhOBTylSVdw/9VxaStYHd7JJGhs36KXkV8ylpbCmYO4ap7/Ue9/slzwpvPOJJzmzAgA==
   dependencies:
-    "@sentry/hub" "7.6.0"
-    "@sentry/types" "7.6.0"
-    "@sentry/utils" "7.6.0"
-    tslib "^1.9.3"
-
-"@sentry/hub@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.6.0.tgz#69a0d11e50ee61f3f93665948c4acbe56a9ce676"
-  integrity sha512-TbieNZInpnR5STXykT1zXoKVAsm8ju1RZyzMqYR8nzURbjlMVVEzFRglNY1Ap5MRkbEuYpAc6zUvgLQe8b6Q3w==
-  dependencies:
-    "@sentry/types" "7.6.0"
-    "@sentry/utils" "7.6.0"
+    "@sentry/hub" "7.8.1"
+    "@sentry/types" "7.8.1"
+    "@sentry/utils" "7.8.1"
     tslib "^1.9.3"
 
 "@sentry/hub@7.8.1":
@@ -672,17 +663,17 @@
     "@sentry/utils" "7.8.1"
     tslib "^1.9.3"
 
-"@sentry/integrations@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.6.0.tgz#7e4026b7a2d830a7724a13908d9ad4b3eede6bb9"
-  integrity sha512-7vjjO04Yz0l1MaY8giZIJro2gAWmLEEhnC/5M9ymjTDJ/bhjDJh3rqSjgZtsoPJS2KXmHskXSRQQXlXVPriUKg==
+"@sentry/integrations@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.8.1.tgz#4a068c1bc44aaa7c8890b1d66641abecd9b84876"
+  integrity sha512-aKMLe+LNA6bOLF3r1t1YjeCsOkUk3f69ldoHbIp9zrYfuCIZBH5AJAsJBCmPnTA4jJotzYEjQfpfb1b/nYBs6A==
   dependencies:
-    "@sentry/types" "7.6.0"
-    "@sentry/utils" "7.6.0"
+    "@sentry/types" "7.8.1"
+    "@sentry/utils" "7.8.1"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/tracing@^7.6.0":
+"@sentry/tracing@7.8.1":
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.8.1.tgz#6368e7e90a43389cd583e77de7e28d5ca6f88bf9"
   integrity sha512-orNVCsMtQUKhvh7GmyJzjOhU6oT7lC7TRT7tTRlyXQVrUmfJZsthmBtyfrTC7QWJ9vXQ0mB4jab8kMT3xE4ltg==
@@ -691,11 +682,6 @@
     "@sentry/types" "7.8.1"
     "@sentry/utils" "7.8.1"
     tslib "^1.9.3"
-
-"@sentry/types@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.6.0.tgz#7352bcc5621177ceefb18733d0a6b0cdb0307822"
-  integrity sha512-POimbDwr9tmHSKksJTXe5VQpvjkFO4/UWUptigwqf8684rkS7Ie2BT2uyp5GD2EgYFf0BwUOWi98FTYTvUGT+Q==
 
 "@sentry/types@7.8.1":
   version "7.8.1"
@@ -709,14 +695,6 @@
   dependencies:
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
-
-"@sentry/utils@7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.6.0.tgz#50b44fd9b06686a358ef2c7c0fd3b80970e1f9ee"
-  integrity sha512-p0Byi6hgawp/sBMY88RY8OmkiAR2jxbjnl8gSo+y3YEu+KeXBUxXMBsI7YeW+1lSb6z8DGhUAOBszTeI4wAr2w==
-  dependencies:
-    "@sentry/types" "7.6.0"
-    tslib "^1.9.3"
 
 "@sentry/utils@7.8.1":
   version "7.8.1"


### PR DESCRIPTION
Yarn lock needs to be updated in order to release a new release.

#skip-changelog.