### PR TITLE
feat: bump sentry-cocoa to 7.23.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ yarn watch
 
 ### iOS
 
-- Basically you'll need to edit SentryCapacitor.podspec and ios/Porfile updating the Sentry dependency and validate it on one of hte examples apps on this proejct.
+- Basically you'll need to edit SentryCapacitor.podspec and ios/Podfile updating the Sentry dependency and validate it on one of hte examples apps on this project.
 - Run 'pod install --repo-update' on the ios folder and then 'yarn build' on the root folder.
 
 ## Running the example apps
@@ -59,7 +59,7 @@ yarn test:watch
 We'd love for users to update the SDK everytime and as soon as we make a new release. But in reality most users rarely update the SDK.
 To help users see value in updating the SDK, we maintain a changelog file with entries split between two headings:
 
-1. `### Features` 
+1. `### Features`
 2. `### Fixes`
 
 We add the heading in the first PR that's adding either a feature or fixes in the current release.

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     miniOSVersion = '13.0' # Required for Capacitor 4 and newer.
   end
   s.ios.deployment_target  = miniOSVersion
-  s.dependency 'Sentry', '~> 7.11.0'
+  s.dependency 'Sentry', '~> 7.23.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,7 +12,7 @@ end
 target 'Plugin' do
   capacitor_pods
 
-  pod 'Sentry', '7.11.0'
+  pod 'Sentry', '7.23.0'
 end
 
 target 'PluginTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Capacitor (3.0.1):
+  - Capacitor (4.1.0):
     - CapacitorCordova
-  - CapacitorCordova (3.0.1)
-  - Sentry (7.11.0):
-    - Sentry/Core (= 7.11.0)
-  - Sentry/Core (7.11.0)
+  - CapacitorCordova (4.1.0)
+  - Sentry (7.23.0):
+    - Sentry/Core (= 7.23.0)
+  - Sentry/Core (7.23.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Sentry (= 7.11.0)
+  - Sentry (= 7.23.0)
 
 SPEC REPOS:
   trunk:
@@ -22,10 +22,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 92088387144015b95e369bd7840e8ef28b8fe9f3
-  CapacitorCordova: 624ae0d33d61b554eda6823da8ea6c3e5170f646
-  Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
+  Capacitor: 525c8f270214dea07bc75b5ca9dc10ac3c0f38d4
+  CapacitorCordova: 63c02d1f0b3b08ccddcbdcbab0087f54135e76b0
+  Sentry: a0d4563fa4ddacba31fdcc35daaa8573d87224d6
 
-PODFILE CHECKSUM: 2584eda3d7d638c17b4e602968d35f66eb0075c8
+PODFILE CHECKSUM: 14dc32b1c8f436a4553ada80b8106fef3580db75
 
 COCOAPODS: 1.11.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,22 +271,22 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@capacitor/android@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-3.0.1.tgz#77deddbde7c3624fdf4b40d3446ac31261f53771"
-  integrity sha512-+bKm0J1/oSln8VlVRfC25AWn+lLFwvC3Q8OeIA7DyI36RPi8WMkGfVPvZ3EIywUKBquj7mVuEXXhiZyM+YlDeQ==
+"@capacitor/android@^3.0.1 || ^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-4.1.0.tgz#d4f4a84213b948911757a00a58255418f126f2c7"
+  integrity sha512-aYHvpYVlS6WC+bG9jJfwqgHMxTw3e8f3taNnl/y9qCjglmMmtFcZWFAVLlOleVK4Q7olSirqjx37f0ppvxRTLg==
 
-"@capacitor/core@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@capacitor/core/-/core-3.0.1.tgz#9e4498034b9e23ac7f3fcfd395fe79185c5d7779"
-  integrity sha512-17iFkpICdOdTqfbKh3oXFYbwXn9dSxLe85PWeptXSW5jkiHN/YhI+iedRpcukv1QXkR1P629B+7kDqBcrzKL9w==
+"@capacitor/core@^3.0.1 || ^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/core/-/core-4.1.0.tgz#4f5b80cd9cbf65bfc5a203082399fa794ffc5f45"
+  integrity sha512-bMYFnC5l5n11D/kLTz9TOOJfUH+nQqYRwzG7h5h4AXIm8aFxH5ZY3iFlDZd7R4xcyrlnfxzfoooSH9trPjRBLA==
   dependencies:
     tslib "^2.1.0"
 
-"@capacitor/ios@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-3.0.1.tgz#189ec4f473424b6435528f7cd68b545b79f1acc0"
-  integrity sha512-g0xQgiGu0MyHl/17tEiMJUAL6sTj76pu3gtqY5wWGLAfTDRodDz2WjmV6i8OQvfrR69IWfdqEvKaFz7MCeHajg==
+"@capacitor/ios@^3.0.1 || ^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-4.1.0.tgz#db3ca463611dccda03244ca4dac41d3b6f69e79c"
+  integrity sha512-zkv48Xc5QwdL7TIT4YpXwgISrA5Cuy59KyN+uq3ovr+L/y5SgtKAOg7pATRBYT7CFgFLqkey/PQKcTjbcxhyaA==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
hey 👋🏻 ! would like to bump sentry-cocoa to latest release as we're getting some false positives for OOM errors and also this warning:

```
We recommend you [update your SDK from sentry.cocoa@v7.11.0 to sentry.cocoa@v7.23.0](https://docs.sentry.io/platforms/cocoa/?_ga=2.14415799.1295930408.1661351982-2002825694.1654264158) (All sentry packages should be updated and their versions should match)
```

NOTE: I've followed the contribution guidelines but not sure about the changes around capacitor 4