### PR TITLE
NIT contributing.md/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@
 
 ## 0.9.0
 
-### Fixes
-
-- Bump Sentry Javascript to fix incompatibility with Sentry Tracing ([#202](https://github.com/getsentry/sentry-capacitor/pull/202))
-
-## 0.8.0
-
 ### Features
 
 - Support for Angular Web ([#199](https://github.com/getsentry/sentry-capacitor/pull/199))
+
+### Fixes
+
+- Bump Sentry Javascript to fix incompatibility with Sentry Tracing ([#202](https://github.com/getsentry/sentry-capacitor/pull/202))
+  - [changelog](https://github.com/getsentry/sentry-javascript/releases/tag/7.8.1)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.6.0...7.8.1)
+
+## 0.8.0
 
 ## 0.7.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ yarn watch
 
 ### iOS
 
-- Basically you'll need to edit SentryCapacitor.podspec and ios/Porfile updating the Sentry dependency and validate it on one of hte examples apps on this proejct.
+- Basically you'll need to edit SentryCapacitor.podspec and ios/Porfile updating the Sentry dependency and validate it on one of the examples apps on this proejct.
 - Run 'pod install --repo-update' on the ios folder and then 'yarn build' on the root folder.
 
 ## Running the example apps


### PR DESCRIPTION
0.9.0 was missing the version bump info and the fixes info was in front of the features info.
fix typo on contributing.md

#skip-changelog