### PR TITLE
Fallback to iOS minimum version 13.0 if Capacitor package was not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fallback to iOS minimun version 13.0 if Capacitor package was not found.
+
 ## 0.10.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fallback to iOS minimun version 13.0 if Capacitor package was not found.
+- Fallback to iOS minimum version 13.0 if Capacitor package was not found ([#225](https://github.com/getsentry/sentry-capacitor/pull/225))
 
 ## 0.10.0
 

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   if File.exist?('../../@capacitor/core/package.json') == false
     # If Capacitor was not found (could happen when using Yarn PNP), fallback to the
-    # required minimun version of Capacitor 4.
+    # required minimum version of Capacitor 4.
     miniOSVersion = '13.0'
   else
     capacitorPackage =  JSON.parse(File.read(File.join(__dir__, '../../@capacitor/core/package.json')))

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -11,12 +11,19 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  capacitorPackage =  JSON.parse(File.read(File.join(__dir__, '../../@capacitor/core/package.json')))
-  capacitorVersion = capacitorPackage['version']
-  if capacitorVersion.start_with?("2.") or capacitorVersion.start_with?("3.")
-    miniOSVersion = '12.0'
+
+  if File.exist?('../../@capacitor/core/package.json') == false
+    # If Capacitor was not found (could happen when using Yarn PNP), fallback to the
+    # required minimun version of Capacitor 4.
+    miniOSVersion = '13.0'
   else
-    miniOSVersion = '13.0' # Required for Capacitor 4 and newer.
+    capacitorPackage =  JSON.parse(File.read(File.join(__dir__, '../../@capacitor/core/package.json')))
+    capacitorVersion = capacitorPackage['version']
+    if capacitorVersion.start_with?("2.") or capacitorVersion.start_with?("3.")
+      miniOSVersion = '12.0'
+    else
+      miniOSVersion = '13.0' # Required for Capacitor 4 and newer.
+    end
   end
   s.ios.deployment_target  = miniOSVersion
   s.dependency 'Sentry', '~> 7.23.0'


### PR DESCRIPTION
Yarn PNP uses a different method of managing Packages, eliminating the need for the node_modules folder. By doing that, the current podspec code is not able to find the Capacitor package to check if the user is using Capacitor 3 or 4.

The fix sets a minimum compatible version with Capacitor 4 if the required package was not found, avoiding the app to not sync due to issues on podspec.

Partially fixes #221