### PR TITLE
Bump Android SDK to 6.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Dependencies
+
+- Bump Sentry Android SDK to `6.4.3` ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+  - [changelog](https://github.com/getsentry/sentry-java/releases/tag/6.4.3)
+  - [diff](https://github.com/getsentry/sentry-java/compare/5.7.0...6.4.3)
+
 ## 0.10.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- Bump Sentry Android SDK to `6.4.3` ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+- Bump Sentry Android SDK to `6.4.3` ([#230](https://github.com/getsentry/sentry-capacitor/pull/230))
   - [changelog](https://github.com/getsentry/sentry-java/releases/tag/6.4.3)
   - [diff](https://github.com/getsentry/sentry-java/compare/5.7.0...6.4.3)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ yarn watch
 
 ## Updating Sentry Native packages
 
+### Android
+
+- Go to android/build.gradle and update the version of `io.sentry:sentry-android`.
+
 ### iOS
 
 - Basically you'll need to edit SentryCapacitor.podspec and ios/Porfile updating the Sentry dependency and validate it on one of the examples apps on this project.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation 'io.sentry:sentry-android:5.7.0'
+    implementation 'io.sentry:sentry-android:6.4.3'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
This PR Bumps Sentry Android 5.7.0 to 6.4.3 and also updates the contributing page.