### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 ## Installation
 
 ```bash
-yarn add @sentry/capacitor @sentry/angular
+yarn add @sentry/capacitor @sentry/angular --exact
 ```
 
 ## Usage


### PR DESCRIPTION
Sentry Capacitor requires the sibling SDKs to be exactly the same. By add the flag `--exact` to yarn, it forces it to use a specific version (in this case the latest one) instead of allowing it to install a different but similar version of Sentry Javascript/Angular/...

#skip-changelog