### PR TITLE
Add sibling check

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ dist
 node_modules
 build
 dangerfile.js
+scripts/check-siblings.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add sibling check ([#248](https://github.com/getsentry/sentry-capacitor/pull/248))
+
 ### Dependencies
 
 - Bump Sentry JavaScript SDK to `7.15.0` ([#244](https://github.com/getsentry/sentry-capacitor/pull/244))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 ## Installation
 
 ```bash
-yarn add @sentry/capacitor @sentry/angular
+yarn add @sentry/capacitor @sentry/angular --exact
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint .",
     "swiftlint": "node-swiftlint",
     "prepublishOnly": "yarn run build",
+    "postinstall": "node scripts/check-siblings.js",
     "bump:v3": "yalc publish && cd example/ionic-angular && yalc add @sentry/capacitor && ionic build && npx cap sync",
     "bump:v2": "yalc publish && cd example/ionic-angular-v2 && yalc add @sentry/capacitor && ionic build && npx cap sync"
   },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "dist/",
     "ios/",
     "android/",
-    "SentryCapacitor.podspec"
+    "SentryCapacitor.podspec",
+    "scripts/check-siblings.js"
   ],
   "capacitor": {
     "ios": {

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+//Filters all Sentry packages but Capacitor itself.
+const jsonFilter = /\s*\"\@sentry\/(?!capacitor)(?<packageName>[a-zA-Z]+)\"\:\s*\"(?<version>.+)\"/;
+const siblingVersion = "7.15.0";
+
+/* TODO: Not valid for all the cases
+// const getDirectories = source =>
+//   fs.readdirSync(source, { withFileTypes: true })
+//     .filter(dirent => dirent.isDirectory())
+//     .map(dirent => dirent.name)
+//
+// Checks the node_modules folder @sentry/capacitor.
+// const capDirectories = getDirectories("node_modules");
+// if(!capDirectories.includes("@sentry")) {
+// There is not conflict with Sentry dependencies so we can skip the post install.
+//       return;
+// }
+*/
+
+// get the location of package.json from the project.
+let rootPath = __dirname + '/../../';
+while (!fs.existsSync(path.resolve(rootPath, 'package.json'))) {
+  rootPath += '../';
+}
+
+const packageJson = fs.readFileSync(rootPath + 'package.json', 'utf8').split("\n");
+for (const lineData of packageJson)
+{
+      let sentryRef = lineData.match(jsonFilter);
+      if (sentryRef && sentryRef[2] !== siblingVersion) {
+            const depName = "@Sentry/" + sentryRef[1];
+            throw "This version of Sentry Capacitor is incompatible with " + depName + " version " + sentryRef[2] + ".\n Please update " + depName + " to version " + siblingVersion + ".";
+      }
+}

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -139,7 +139,7 @@ if (incompatiblePackages.length > 0) {
             IncompatibilityError += package[0] + ' version ' + package[1] + '\n';
             packagesList += package[0] + '@' + siblingVersion + ' ';
       }
-      IncompatibilityError += 'Please install the mentioned packages with exactly with version ' + siblingVersion + ' and with the argument ' + updateArgument + '\n';
+      IncompatibilityError += 'Please install the mentioned packages exactly with version ' + siblingVersion + ' and with the argument ' + updateArgument + '\n';
       IncompatibilityError += FormatPackageInstallCommand(packagesList) + '\n';
       throw IncompatibilityError;
 }

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -5,7 +5,7 @@ const { env } = require('process');
 const updateArgument = '--update-sentry-capacitor';
 
 // Filters all Sentry packages but Capacitor, CLI and Wizard.
-const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli)(?<packageName>[a-zA-Z]+)\"\:\s*\"(?<version>.+)\"/;
+const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript)(?<packageName>[a-zA-Z]+)\"\:\s*\"(?<version>.+)\"/;
 
 /**
  * If user requested to ignore the post-install
@@ -58,7 +58,7 @@ function GetRequiredSiblingVersion() {
  */
 function ValidateSentryPackageParameters(packages) {
   let errorMessages = [];
-  var packageFilter = /.*(capacitor|cli|wizard)/;
+  var packageFilter = /.*(capacitor|cli|wizard|typescript)/;
   for (const argPackage of packages) {
     if (argPackage.startsWith('@sentry') && !packageFilter.test(argPackage)) {
       const installedVersion = String(argPackage);


### PR DESCRIPTION
The goal is to better inform the user that Sentry/Capacitor requires the exact version on the Sibling SDKs as defined on the peerDependency.

This code will look for any @sentry/package references on the packages.json file from the user's project, if those references doesn't match the required one by the script, the script will warn the user about it when a dependency gets installed or updated.

Some questions in regard to this feature:

- Should it feature just warn the user or throw an error when installing/updating the dependency?

If we throw an error, the user will only be able to update the project if he/she updates all sibling dependencies in one command (ie yarn add @sentry/angular@7.15.0 @sentry/hub@7.15.0 @sentry/capacitor@0.11.0 --exact)

Fixes #45, #218, #268