### PR TITLE
Avoid duplicating Breadcrumbs on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Avoid duplicating Breadcrumbs on Android ([#254](https://github.com/getsentry/sentry-capacitor/pull/254))
+
 ### Dependencies
 
 - Bump Sentry JavaScript SDK to `7.15.0` ([#244](https://github.com/getsentry/sentry-capacitor/pull/244))

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -44,8 +44,10 @@ export const NATIVE = {
         We then remove the breadcrumbs in all cases but if it is handled == false,
         this is a signal that the app would crash and android would lose the breadcrumbs by the time the app is restarted to read
         the envelope.
+        Since unhandled errors from Javascript are not going to crash the App, we can't rely on the
+        handled flag for filtering breadcrumbs.
           */
-          if (event.exception?.values?.[0]?.mechanism?.handled != false && event.breadcrumbs) {
+          if (event.breadcrumbs) {
             event.breadcrumbs = [];
           }
         }

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -306,7 +306,7 @@ describe('Tests Native Wrapper', () => {
         exception: {
           values: [{
             mechanism: {
-              handled: false
+              handled: true
             }
           }]
         },
@@ -327,18 +327,14 @@ describe('Tests Native Wrapper', () => {
       });
       const expectedPayload = JSON.stringify({
         ...event,
-        breadcrumbs: [
-          {
-            message: 'crumb!',
-          },
-        ],
+        breadcrumbs: [],
         message: {
           message: event.message,
         },
         exception: {
           values: [{
             mechanism: {
-              handled: false
+              handled: true
             }
           }]
         }


### PR DESCRIPTION
Unhandled Exceptions doesn't crash the app, unlike React Native, so we shouldn't validate the Handled flag for clearing the breadcrumbs.

For context: Both SDKs have the same Breadcrumbs, we clear them on the Android Wrapper because the Android SDK will apply the same breadcrumbs to the captured event.

Fixes #232