### PR TITLE
fix incorrect reference to package.json under special cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes/Features
+
+- fix incorrect reference to package.json under special cases ([#316](https://github.com/getsentry/sentry-capacitor/pull/316))
+
 ## 0.11.1
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes/Features
 
-- fix incorrect reference to package.json under special cases ([#316](https://github.com/getsentry/sentry-capacitor/pull/316))
+- Fix incorrect reference to package.json under special cases ([#316](https://github.com/getsentry/sentry-capacitor/pull/316))
 
 ## 0.11.1
 

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -38,8 +38,11 @@ function GetRequiredSiblingVersion() {
     // NPM.
     capacitorPackagePath = env.npm_package_json;
   }
+  else if (__dirname) {
+    capacitorPackagePath = path.join(__dirname, '..', 'package.json');
+  }
   else {
-    capacitorPackagePath = __dirname + '../package.json';
+    return undefined;
   }
 
   const capacitorPackageJson = fs.readFileSync(capacitorPackagePath, 'utf8');


### PR DESCRIPTION
This PR fixes an incorrect reference  to the package.json.

The path.join() method concatenates all given path segments into a single path, handling the appropriate platform-specific separators and making it less prone to errors.

Fixes #298