### PR TITLE
Bump Sentry Javascript 7.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Fix incorrect reference to package.json under special cases ([#316](https://github.com/getsentry/sentry-capacitor/pull/316))
 
+### Dependencies
+
+- Bump Sentry JavaScript SDK to `7.37.1` ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+  - [changelog](https://github.com/getsentry/sentry-javascript/releases/tag/7.37.1)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.31.1...7.37.1)
+
 ## 0.11.1
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Dependencies
 
-- Bump Sentry JavaScript SDK to `7.37.1` ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+- Bump Sentry JavaScript SDK to `7.37.1` ([#320](https://github.com/getsentry/sentry-capacitor/pull/320))
   - [changelog](https://github.com/getsentry/sentry-javascript/releases/tag/7.37.1)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.31.1...7.37.1)
 

--- a/example/ionic-angular/package.json
+++ b/example/ionic-angular/package.json
@@ -14,9 +14,9 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^5.0.0",
-    "@sentry/angular": "7.31.1",
+    "@sentry/angular": "7.37.1",
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
-    "@sentry/replay": "7.31.1",
+    "@sentry/replay": "7.37.1",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"

--- a/example/ionic-angular/yarn.lock
+++ b/example/ionic-angular/yarn.lock
@@ -1634,37 +1634,37 @@
     "@angular-devkit/schematics" "13.3.0"
     jsonc-parser "3.0.0"
 
-"@sentry/angular@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/angular/-/angular-7.31.1.tgz#07e6df9c85a0672ec614c021c58837ff63265545"
-  integrity sha512-TNb7n0wmoavy/Fpjf06sfMFh/6ML8PIJgYVbiYJDZwkdonmUwlP1ik7KyfbxTmRHE8DRC5H0S5Z4WCSTLnc7nA==
+"@sentry/angular@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/angular/-/angular-7.37.1.tgz#895729c9b3b7bb0676a986d421b8d9c605a0bc33"
+  integrity sha512-je0xIeVuStNBZJODKNDfDzWhieNavha9s12rH/bs5kr0YnHSdU8dQQk2aBFKFMg9XKwuqE8E2Iyg47INl4OcXA==
   dependencies:
-    "@sentry/browser" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/browser" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^2.0.0"
 
-"@sentry/browser@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.31.1.tgz#ac42ef5994d0e983e4c44c35b17013a0080c6527"
-  integrity sha512-Rg9F61S1tz1Dv3iUyyGP26bxoi7WJAG2+f2fBbSmFuJ+JTH4Jvu2/F1bBig8Dz01ejzVhbNSUUCfoDhSvksIsQ==
+"@sentry/browser@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.37.1.tgz#d452ebed7f974f20872d34744e67d856ab54a41b"
+  integrity sha512-MfVbKzEVHKVH6ZyMCKLtPXvMtRCvxqQzrnK735sYW6EyMpcMYhukBU0pq7ws1E/KaCZjAJi1wDx2nqf2yPIVdQ==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/replay" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/replay" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor":
-  version "0.11.0"
+  version "0.11.1"
   dependencies:
-    "@sentry/browser" "7.31.1"
-    "@sentry/core" "7.31.1"
-    "@sentry/hub" "7.31.1"
-    "@sentry/integrations" "7.31.1"
-    "@sentry/tracing" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/browser" "7.37.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/hub" "7.37.1"
+    "@sentry/integrations" "7.37.1"
+    "@sentry/tracing" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     "@sentry/wizard" "^1.1.4"
     promise "^8.1.0"
 
@@ -1681,65 +1681,65 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.31.1.tgz#8c48e9c6a24b612eb7f757fdf246ed6b22c26b3b"
-  integrity sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==
+"@sentry/core@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.37.1.tgz#6d8d151b3d6ae0d6f81c7f4da92cd2e7cb5bf1fa"
+  integrity sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==
   dependencies:
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/hub@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.31.1.tgz#a1b7031551c6e0a1e2f2eddf7a5ced2f4627264e"
-  integrity sha512-Hg0kjQSISecNL6ZqlyZLUY+QB/lwN12xTvOX/sf4007ApEi7UutQI954AkcmXXw97Kt8Of12ElgUO/9+Jj86VQ==
+"@sentry/hub@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.37.1.tgz#ea33df094990dbff5dcb67e82bcfecb9b7ed5ac3"
+  integrity sha512-l0JVIAXngLd7LiNgBiasuK9YtTw5SvaOsedyLqNlb6dYFHfJTHZggVzQtu+F4oSzCBE4ld4DHJCCzQUQFEjIrw==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/integrations@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.31.1.tgz#abca1e87687049f305dc4514d0d287b643fe43af"
-  integrity sha512-El+qzwbiXHPDWg8ZmX+W/kCheoaYoaAJuaG2+l3D5Y4ny8JNYfSMCum9qXVEb8oB98fFHfSEoFzB+z54pH+p3w==
+"@sentry/integrations@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.37.1.tgz#69031ab877b78ee68a46bfaa70d90b0de691757e"
+  integrity sha512-/7VZXw7/DxZPsGNEaU/gcKRNPtmK75mz9oM71C5UbRDDEdFSEeVq2jG+tOq2lIsd2VQlsAmN3DG5yqiGA9C4eQ==
   dependencies:
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/replay@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.31.1.tgz#453ad85fc2f14e4d203d3a7e0bf790877f697964"
-  integrity sha512-sLArvwZn6IwA/bASctyhxN7LhdCXJvMmyTynRfmk7pzuNzBMc5CNlHeIsDpHrfQuH53IKicvl6cHnHyclu5DSA==
+"@sentry/replay@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.37.1.tgz#8ab4588b28baa07e35c417d3ffc6aaf934c58c45"
+  integrity sha512-3sHOE/oPirdvJbOn0IA/wpds12Sm2WaEtiAeC0+5Gg5mxQzFBLRrsA1Mz/ifzPGwr+ETn3sCyPCnd9b3PWaWMQ==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
 
-"@sentry/tracing@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.31.1.tgz#f3bf8ca3aa9ddc15c282425df8043be978baadb4"
-  integrity sha512-kW6vNwddp2Ycq2JfTzveUEIRF9YQwvl7L6BBoOZt9oVnYlsPipEeyU2Q277LatHldr8hDo2tbz/vz2BQjO5GSw==
+"@sentry/tracing@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.37.1.tgz#f5db7990f09be8d3c6b621b3718c268fff163ba0"
+  integrity sha512-3mQG2XtMCGqDkgfzhKpRJAIfRaokNAOF8WafgAmFmZQwEDsRAFjZ3pLoO+KiBUeQE5E5et7HyWBOl9rqHCkWnQ==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/types@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.31.1.tgz#920fc10b289ac1f99f277033b4d26625028a1f9f"
-  integrity sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==
+"@sentry/types@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.37.1.tgz#269da7da39c1a5243bf5f9a35370291b5cc205bb"
+  integrity sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==
 
-"@sentry/utils@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.31.1.tgz#bdc988de603318a30ff247d5702c2f9ac81255cb"
-  integrity sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==
+"@sentry/utils@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.37.1.tgz#7695d6e30d6178723f3fa446a9553893bca85e96"
+  integrity sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==
   dependencies:
-    "@sentry/types" "7.31.1"
+    "@sentry/types" "7.37.1"
     tslib "^1.9.3"
 
 "@sentry/wizard@^1.1.4":

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   "license": "MIT",
   "peerDependencies": {
     "@capacitor/core": ">=3.0.0",
-    "@sentry/angular": "7.31.1",
-    "@sentry/react": "7.31.1",
-    "@sentry/vue": "7.31.1"
+    "@sentry/angular": "7.37.1",
+    "@sentry/react": "7.37.1",
+    "@sentry/vue": "7.37.1"
   },
   "peerDependenciesMeta": {
     "@sentry/angular": {
@@ -54,13 +54,13 @@
     }
   },
   "dependencies": {
-    "@sentry/browser": "7.31.1",
-    "@sentry/core": "7.31.1",
-    "@sentry/hub": "7.31.1",
-    "@sentry/integrations": "7.31.1",
-    "@sentry/tracing": "7.31.1",
-    "@sentry/types": "7.31.1",
-    "@sentry/utils": "7.31.1",
+    "@sentry/browser": "7.37.1",
+    "@sentry/core": "7.37.1",
+    "@sentry/hub": "7.37.1",
+    "@sentry/integrations": "7.37.1",
+    "@sentry/tracing": "7.37.1",
+    "@sentry/types": "7.37.1",
+    "@sentry/utils": "7.37.1",
     "@sentry/wizard": "^1.1.4",
     "promise": "^8.1.0"
   },
@@ -69,8 +69,8 @@
     "@capacitor/core": "^3.0.1 || ^4.0.0",
     "@capacitor/ios": "^3.0.1 || ^4.0.0",
     "@ionic/prettier-config": "^1.0.0",
-    "@sentry-internal/eslint-config-sdk": "7.31.1",
-    "@sentry-internal/eslint-plugin-sdk": "7.31.1",
+    "@sentry-internal/eslint-config-sdk": "7.37.1",
+    "@sentry-internal/eslint-plugin-sdk": "7.37.1",
     "@sentry/typescript": "5.20.1",
     "@types/jest": "^26.0.15",
     "eslint": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,13 +617,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sentry-internal/eslint-config-sdk@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.31.1.tgz#4473f01a7ef9c0facc5326893ca350d85da21041"
-  integrity sha512-RGgBa+sF4W7z8emW+4+r8xgVQtpSqfYSJMmU9wVe/UfIERNLnpj00pK4Vg4Bxbxiwf9TnXG/MyN3qyfJqqUpQw==
+"@sentry-internal/eslint-config-sdk@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.37.1.tgz#1dafb9edbe7df94fb791c95aff80b6437f60a36a"
+  integrity sha512-jdkt6DG0+IwctiH8J1be8ZyQlgDyzkeJvhEZv8D/ZdCM5tqjvUqkbqS1yVTfwV+5OfjIMnQ4I9D/5Fnt8V14Rg==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.31.1"
-    "@sentry-internal/typescript" "7.31.1"
+    "@sentry-internal/eslint-plugin-sdk" "7.37.1"
+    "@sentry-internal/typescript" "7.37.1"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -632,27 +632,27 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.31.1.tgz#d08b96a7d892d83c6644aa136d33f63e523ead51"
-  integrity sha512-nXoDrgpJiRvKr2DIm556XE0MwLUM5LNatfBVzmJgOd57b2kCh2MamYCZBlqjmLvJ3cB/nYlG9xK4CKBPynXxcQ==
+"@sentry-internal/eslint-plugin-sdk@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.37.1.tgz#9f6da2b0c711edeca628cb76eedf5f4776863dd2"
+  integrity sha512-SENuFIWVzb7xDEOdQTV8/i4EUb+s9ro6QWM/etXALQGE/Cvdors4YzTzfm3dJzV0Uk5DF3IPwdwQvimEeOsXHA==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.31.1.tgz#efba3403d7539d4b106cac867f02cae330910af1"
-  integrity sha512-nYuLczcPd4PtKjfgdDMEGAczREBTtUTr1hjMZSafCMY4FUwdns9VKu4Eb13nrrytmF2zyqcCg4pPAXRuaeUAbA==
+"@sentry-internal/typescript@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.37.1.tgz#69ab51dc699eef56478da115789999dedb762e07"
+  integrity sha512-DEgaC5noRaY7WHM2XKEDRKbO01LtI4TVYxdbEgZQUmQX7FV1Ql27otHtEGiMBKe8JqoRHYm+Q3J9ZRtblMDERQ==
 
-"@sentry/browser@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.31.1.tgz#ac42ef5994d0e983e4c44c35b17013a0080c6527"
-  integrity sha512-Rg9F61S1tz1Dv3iUyyGP26bxoi7WJAG2+f2fBbSmFuJ+JTH4Jvu2/F1bBig8Dz01ejzVhbNSUUCfoDhSvksIsQ==
+"@sentry/browser@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.37.1.tgz#d452ebed7f974f20872d34744e67d856ab54a41b"
+  integrity sha512-MfVbKzEVHKVH6ZyMCKLtPXvMtRCvxqQzrnK735sYW6EyMpcMYhukBU0pq7ws1E/KaCZjAJi1wDx2nqf2yPIVdQ==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/replay" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/replay" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.52.4":
@@ -666,58 +666,58 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.31.1.tgz#8c48e9c6a24b612eb7f757fdf246ed6b22c26b3b"
-  integrity sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==
+"@sentry/core@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.37.1.tgz#6d8d151b3d6ae0d6f81c7f4da92cd2e7cb5bf1fa"
+  integrity sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==
   dependencies:
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/hub@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.31.1.tgz#a1b7031551c6e0a1e2f2eddf7a5ced2f4627264e"
-  integrity sha512-Hg0kjQSISecNL6ZqlyZLUY+QB/lwN12xTvOX/sf4007ApEi7UutQI954AkcmXXw97Kt8Of12ElgUO/9+Jj86VQ==
+"@sentry/hub@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.37.1.tgz#ea33df094990dbff5dcb67e82bcfecb9b7ed5ac3"
+  integrity sha512-l0JVIAXngLd7LiNgBiasuK9YtTw5SvaOsedyLqNlb6dYFHfJTHZggVzQtu+F4oSzCBE4ld4DHJCCzQUQFEjIrw==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/integrations@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.31.1.tgz#abca1e87687049f305dc4514d0d287b643fe43af"
-  integrity sha512-El+qzwbiXHPDWg8ZmX+W/kCheoaYoaAJuaG2+l3D5Y4ny8JNYfSMCum9qXVEb8oB98fFHfSEoFzB+z54pH+p3w==
+"@sentry/integrations@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.37.1.tgz#69031ab877b78ee68a46bfaa70d90b0de691757e"
+  integrity sha512-/7VZXw7/DxZPsGNEaU/gcKRNPtmK75mz9oM71C5UbRDDEdFSEeVq2jG+tOq2lIsd2VQlsAmN3DG5yqiGA9C4eQ==
   dependencies:
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/replay@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.31.1.tgz#453ad85fc2f14e4d203d3a7e0bf790877f697964"
-  integrity sha512-sLArvwZn6IwA/bASctyhxN7LhdCXJvMmyTynRfmk7pzuNzBMc5CNlHeIsDpHrfQuH53IKicvl6cHnHyclu5DSA==
+"@sentry/replay@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.37.1.tgz#8ab4588b28baa07e35c417d3ffc6aaf934c58c45"
+  integrity sha512-3sHOE/oPirdvJbOn0IA/wpds12Sm2WaEtiAeC0+5Gg5mxQzFBLRrsA1Mz/ifzPGwr+ETn3sCyPCnd9b3PWaWMQ==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
 
-"@sentry/tracing@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.31.1.tgz#f3bf8ca3aa9ddc15c282425df8043be978baadb4"
-  integrity sha512-kW6vNwddp2Ycq2JfTzveUEIRF9YQwvl7L6BBoOZt9oVnYlsPipEeyU2Q277LatHldr8hDo2tbz/vz2BQjO5GSw==
+"@sentry/tracing@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.37.1.tgz#f5db7990f09be8d3c6b621b3718c268fff163ba0"
+  integrity sha512-3mQG2XtMCGqDkgfzhKpRJAIfRaokNAOF8WafgAmFmZQwEDsRAFjZ3pLoO+KiBUeQE5E5et7HyWBOl9rqHCkWnQ==
   dependencies:
-    "@sentry/core" "7.31.1"
-    "@sentry/types" "7.31.1"
-    "@sentry/utils" "7.31.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/types@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.31.1.tgz#920fc10b289ac1f99f277033b4d26625028a1f9f"
-  integrity sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==
+"@sentry/types@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.37.1.tgz#269da7da39c1a5243bf5f9a35370291b5cc205bb"
+  integrity sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==
 
 "@sentry/typescript@5.20.1":
   version "5.20.1"
@@ -727,12 +727,12 @@
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
 
-"@sentry/utils@7.31.1":
-  version "7.31.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.31.1.tgz#bdc988de603318a30ff247d5702c2f9ac81255cb"
-  integrity sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==
+"@sentry/utils@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.37.1.tgz#7695d6e30d6178723f3fa446a9553893bca85e96"
+  integrity sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==
   dependencies:
-    "@sentry/types" "7.31.1"
+    "@sentry/types" "7.37.1"
     tslib "^1.9.3"
 
 "@sentry/wizard@^1.1.4":


### PR DESCRIPTION
This PR Bumps Sentry Javascript from version to 7.31.1 to 7.37.1