### PR TITLE
Ignore Sentry Electron from Sibling Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-### Fixes/Features
+### Fixes
 
+- Fix ignore sibling check on Sentry Electron ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
 - Fix incorrect reference to package.json under special cases ([#316](https://github.com/getsentry/sentry-capacitor/pull/316))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix ignore sibling check on Sentry Electron ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+- Fix ignore sibling check on Sentry Electron ([#324](https://github.com/getsentry/sentry-capacitor/pull/324))
 - Fix incorrect reference to package.json under special cases ([#316](https://github.com/getsentry/sentry-capacitor/pull/316))
 
 ### Dependencies

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -5,7 +5,7 @@ const { env } = require('process');
 const updateArgument = '--update-sentry-capacitor';
 
 // Filters all Sentry packages but Capacitor, CLI and Wizard.
-const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript)(?<packageName>[a-zA-Z]+)\"\:\s*\"(?<version>.+)\"/;
+const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript|electron)(?<packageName>[a-zA-Z]+)\"\:\s*\"(?<version>.+)\"/;
 
 /**
  * If user requested to ignore the post-install


### PR DESCRIPTION
Sentry Electron uses a different versioning number so it should be ignored from the sibling check, otherwise users will have to ignore the sibling check order to use the SDK.