### PR TITLE
add stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+name: "close stale issues/PRs"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
+        with:
+          repo-token: ${{ github.token }}
+          days-before-stale: 21
+          days-before-close: 7
+          only-labels: ""
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          debug-only: false
+          ascending: false
+
+          exempt-issue-labels: "Status: Backlog,Status: In Progress"
+          stale-issue-label: "Status: Stale"
+          stale-issue-message: |-
+            This issue has gone three weeks without activity. In another week, I will close it.
+
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Backlog` or `Status: In Progress`, I will leave it alone ... forever!
+
+            ----
+
+            "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
+          close-issue-label: ""
+          close-issue-message: ""
+
+          exempt-pr-labels: "Status: Backlog,Status: In Progress"
+          stale-pr-label: "Status: Stale"
+          stale-pr-message: |-
+            This pull request has gone three weeks without activity. In another week, I will close it.
+
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Backlog` or `Status: In Progress`, I will leave it alone ... forever!
+
+            ----
+
+            "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
+          skip-stale-pr-message: false
+          close-pr-label:
+          close-pr-message: ""


### PR DESCRIPTION
After reviewing some Issues I noticed that some old issues didn't have any stale warning.

So I just added the missing Github integration that Sentry uses on other Projects.

In this case, it's basically the same implementation as the one done on React Native: https://github.com/getsentry/sentry-react-native/blob/main/.github/workflows/stale.yml

#skip-changelog