### PR TITLE
Fix iOS not Sending events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix iOS not Sending events ([#370](https://github.com/getsentry/sentry-capacitor/pull/370))
+
 ## 0.11.3
 
 ### Fixes

--- a/src/nativeOptions.ts
+++ b/src/nativeOptions.ts
@@ -1,0 +1,36 @@
+import type { CapacitorOptions } from './options';
+
+/**
+ * Create a new CapacitorOption without any parameter that could crash the bridge (in short, not being a string, number or boolean).
+ * some of the excluded parameters are: Integrations, app, vue, beforeSend, beforeBreadcrumb, integrations, defaultIntegrations, transport, tracesSampler.
+ * @param options CapacitorOptions
+ */
+export function FilterNativeOptions(options: CapacitorOptions): CapacitorOptions {
+  return {
+    // allowUrls: Only available on the JavaScript Layer.
+    attachStacktrace: options.attachStacktrace,
+    attachThreads: options.attachThreads,
+    debug: options.debug,
+    // denyUrls Only available on the JavaScript Layer.
+    dist: options.dist,
+    dsn: options.dsn,
+    enabled: options.enabled,
+    enableNdkScopeSync: options.enableNdkScopeSync,
+    enableOutOfMemoryTracking: options.enableOutOfMemoryTracking,
+    enableTracing: options.enableTracing,
+    environment: options.environment,
+    // ignoreErrors: Only available on the JavaScript Layer.
+    // ignoreTransactions: Only available on the JavaScript Layer.
+    maxBreadcrumbs: options.maxBreadcrumbs,
+    // maxValueLength: Only available on the JavaScript Layer.
+    release: options.release,
+    // replaysOnErrorSampleRate: Only handled on the JavaScript Layer.
+    // replaysSessionSampleRate: Only handled on the JavaScript Layer.
+    sampleRate: options.sampleRate,
+    sendClientReports: options.sendClientReports,
+    sendDefaultPii: options.sendDefaultPii,
+    sessionTrackingIntervalMillis: options.sessionTrackingIntervalMillis,
+    tracesSampleRate: options.tracesSampleRate,
+    // tunnel: options.tunnel: Only handled on the JavaScript Layer.
+  };
+}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -3,6 +3,7 @@ import type { BaseEnvelopeItemHeaders, Breadcrumb, Envelope, EnvelopeItem, Event
 import { dropUndefinedKeys, logger, SentryError } from '@sentry/utils';
 
 import type { NativeDeviceContextsResponse } from './definitions';
+import { FilterNativeOptions } from './nativeOptions';
 import type { CapacitorOptions } from './options';
 import { SentryCapacitor } from './plugin';
 import { utf8ToBytes } from './vendor';
@@ -96,21 +97,7 @@ export const NATIVE = {
     }
 
     // filter out all options that would crash native
-    /* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unused-vars */
-    const {
-      // @ts-ignore Vue specific option.
-      app,
-      // @ts-ignore Vue specific option.
-      vue,
-      beforeSend,
-      beforeBreadcrumb,
-      integrations,
-      defaultIntegrations,
-      transport,
-      tracesSampler,
-      ...filteredOptions
-    } = options;
-
+    const filteredOptions = FilterNativeOptions(options);
     return SentryCapacitor.initNativeSdk({ options: filteredOptions });
   },
 

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -1,0 +1,68 @@
+import type { Instrumenter, StackParser } from '@sentry/types';
+
+import { FilterNativeOptions } from '../src/nativeOptions';
+
+describe('nativeOptions', () => {
+  test('invalid types not included', async () => {
+    const nativeOptions = FilterNativeOptions(
+      {
+        _experiments: [true],
+        _metadata: {},
+        allowUrls: ['test'],
+        attachStacktrace: true,
+        attachThreads: true,
+        beforeBreadcrumb: ((bread) => bread),
+        beforeSend: ((evt) => evt),
+        beforeSendTransaction: ((transaction) => transaction),
+        debug: true,
+        defaultIntegrations: [],
+        denyUrls: [],
+        dist: '1',
+        dsn: 'dns',
+        enableAutoSessionTracking: true,
+        enabled: true,
+        enableNative: true,
+        enableNativeCrashHandling: true,
+        enableNativeNagger: true,
+        enableNdkScopeSync: true,
+        enableOutOfMemoryTracking: true,
+        enableTracing: true,
+        environment: 'Prod',
+        ignoreErrors: ['test'],
+        ignoreTransactions: ['test'],
+        initialScope: {},
+        instrumenter: {} as Instrumenter,
+        integrations: [],
+        maxBreadcrumbs: 100,
+        maxValueLength: 100,
+        normalizeDepth: 100,
+        normalizeMaxBreadth: 100,
+        release: '1',
+        replaysOnErrorSampleRate: 1,
+        replaysSessionSampleRate: 1,
+        sampleRate: 1,
+        sendClientReports: true,
+        sendDefaultPii: true,
+        sessionTrackingIntervalMillis: 10,
+        shutdownTimeout: 10,
+        stackParser: {} as StackParser,
+        tracesSampler: ((_) => 1),
+        tracesSampleRate: 1,
+        transportOptions: {},
+        tunnel: 'test',
+      });
+
+    const keys = Object.keys(nativeOptions);
+    const keysFilter = keys.filter(key =>
+      // @ts-ignore allowed for testing.
+      (typeof nativeOptions[key]) !== 'string' &&
+      // @ts-ignore allowed for testing.
+      (typeof nativeOptions[key]) !== 'number' &&
+      // @ts-ignore allowed for testing.
+      (typeof nativeOptions[key]) !== 'boolean' &&
+      // @ts-ignore allowed for testing.
+      (typeof nativeOptions[key]) !== undefined)
+
+    expect(keysFilter.toString()).toBe('');
+  });
+});

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -87,7 +87,7 @@ describe('Tests Native Wrapper', () => {
       expect(SentryCapacitor.initNativeSdk).toBeCalled();
     });
 
-    test('Vue options to be removed', async () => {
+    test('Vue and App options to be removed', async () => {
 
       const initNativeSdk = jest.spyOn(SentryCapacitor, 'initNativeSdk');
 
@@ -100,6 +100,35 @@ describe('Tests Native Wrapper', () => {
       expect(nativeOption.app).toBeUndefined();
       // @ts-ignore Not part of Capacitor Options but it is extended by Vue Options.
       expect(nativeOption.vue).toBeUndefined();
+
+      expect(initNativeSdk).toBeCalled();
+    });
+
+
+    test('default options to be removed', async () => {
+      const initNativeSdk = jest.spyOn(SentryCapacitor, 'initNativeSdk');
+      await NATIVE.initNativeSdk(
+        {
+          dsn: 'test',
+          enableNative: true,
+          integrations: [],
+          defaultIntegrations: [],
+          beforeSend: ((event) => event),
+          beforeBreadcrumb: ((breadcrumb) => breadcrumb),
+          transport: jest.fn(),
+          tracesSampler: jest.fn(),
+        });
+
+      const nativeOption = initNativeSdk.mock.calls[0][0].options;
+      expect(SentryCapacitor.initNativeSdk).toBeCalledTimes(1);
+      // @ts-ignore Not part of Capacitor Options but it is extended by Vue Options.
+      expect(nativeOption.integrations).toBeUndefined();
+      expect(nativeOption.defaultIntegrations).toBeUndefined();
+      expect(nativeOption.beforeSend).toBeUndefined();
+      expect(nativeOption.beforeBreadcrumb).toBeUndefined();
+      expect(nativeOption.beforeBreadcrumb).toBeUndefined();
+      expect(nativeOption.transport).toBeUndefined();
+      expect(nativeOption.tracesSampler).toBeUndefined();
 
       expect(initNativeSdk).toBeCalled();
     });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -66,6 +66,7 @@ jest.mock('../src/plugin', () => {
 });
 
 import { SentryCapacitor } from '../src/plugin';
+import { transcode } from 'buffer';
 
 beforeEach(() => {
   getStringBytesLengthValue = 1;
@@ -115,6 +116,7 @@ describe('Tests Native Wrapper', () => {
           defaultIntegrations: [],
           beforeSend: ((event) => event),
           beforeBreadcrumb: ((breadcrumb) => breadcrumb),
+          beforeSendTransaction: (transaction) => transaction,
           transport: jest.fn(),
           tracesSampler: jest.fn(),
         });
@@ -125,7 +127,7 @@ describe('Tests Native Wrapper', () => {
       expect(nativeOption.integrations).toBeUndefined();
       expect(nativeOption.defaultIntegrations).toBeUndefined();
       expect(nativeOption.beforeSend).toBeUndefined();
-      expect(nativeOption.beforeBreadcrumb).toBeUndefined();
+      expect(nativeOption.beforeSendTransaction).toBeUndefined();
       expect(nativeOption.beforeBreadcrumb).toBeUndefined();
       expect(nativeOption.transport).toBeUndefined();
       expect(nativeOption.tracesSampler).toBeUndefined();

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -66,7 +66,6 @@ jest.mock('../src/plugin', () => {
 });
 
 import { SentryCapacitor } from '../src/plugin';
-import { transcode } from 'buffer';
 
 beforeEach(() => {
   getStringBytesLengthValue = 1;


### PR DESCRIPTION
Reworked the Capacitor Options sent to native in order to only allow parameters that are supported, the previous filter was weak since new types and custom ones added by the users could have the risk of breaking the native initialisation on iOS.

Fixes #338, may also fix #337