### PR TITLE
Fix Deprecated references to Sdk Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix Deprecated references to Sdk Info ([#376](https://github.com/getsentry/sentry-capacitor/pull/376))
 - Fix iOS not Sending events ([#370](https://github.com/getsentry/sentry-capacitor/pull/370))
 
 ## 0.11.3

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -119,13 +119,9 @@ public class SentryCapacitor: CAPPlugin {
     }
 
     @objc func fetchNativeSdkInfo(_ call: CAPPluginCall) {
-        guard let options = self.sentryOptions else {
-            return call.reject("Called fetchSdkInfo without initializing cocoa SDK.")
-        }
-
         call.resolve([
-            "name": options.sdkInfo.name,
-            "version": options.sdkInfo.version
+            "name": PrivateSentrySDKOnly.getSdkName(),
+            "version": PrivateSentrySDKOnly.getSdkVersionString()
         ])
     }
 


### PR DESCRIPTION
This data was moved to the private Private SDK

Fixes #351