### PR TITLE
chore: Update CHANGELOG for 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+This release does not include changes.
+It only fixes NPM's `latest` pointer to correctly point to version 12.x instead of 11.x.
+
 ## 0.11.5
 
 ### Fixes


### PR DESCRIPTION
While trying to resolve the incident around our release registry being out of sync we noticed that the last release of `@sentry/capacitor@0.11.5` was made after `@sentry/capacitor@0.12.1` was already released. This "incorrectly" redirected NPM's `latest` pointer to `0.11.5` instead of `0.12.1`. The simplest way to fix this is to release a new 0.12.x version so this PR updates the changelog for it.

#skip-changelog

(Note: Alternatively, merging any open PR that updates the changelog would also do. Happy to close this if we can make a somewhat meaningful release)