### PR TITLE
Fix error when serializing objects with circular referencing

### DIFF
--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,6 +1,7 @@
 import { Scope } from '@sentry/core';
 import type { Breadcrumb, User } from '@sentry/types';
 
+import { convertToNormalizedObject } from './utils/normalize';
 import { NATIVE } from './wrapper';
 
 /**
@@ -69,9 +70,13 @@ export class CapacitorScope extends Scope {
    * @inheritDoc
    */
   public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    /* eslint-disable no-console */
-    NATIVE.addBreadcrumb(breadcrumb);
-    return super.addBreadcrumb(breadcrumb, maxBreadcrumbs);
+    const mergedBreadcrumb: Breadcrumb = {
+      ...breadcrumb,
+      data: breadcrumb.data ? convertToNormalizedObject(breadcrumb.data) : undefined,
+    };
+
+    NATIVE.addBreadcrumb(mergedBreadcrumb);
+    return super.addBreadcrumb(mergedBreadcrumb, maxBreadcrumbs);
   }
 
   /**

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,0 +1,19 @@
+import { normalize } from '@sentry/utils';
+
+const KEY = 'value';
+
+/**
+ * Converts any input into a valid record with string keys.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function convertToNormalizedObject(data: unknown): Record<string, any> {
+  const normalized: unknown = normalize(data);
+  if (normalized === null || typeof normalized !== 'object') {
+    return {
+      [KEY]: normalized,
+    };
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return normalized as Record<string, any>;
+  }
+}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -349,7 +349,7 @@ export const NATIVE = {
         (_key, value) =>
           typeof value === 'object' && value !== null
             ? cache.includes(value)
-              ? '[Circular ...]' // Duplicate reference found, discard key
+              ? '[Circular...]' // Duplicate reference found, discard key
               : cache.push(value) && value // Store value in our collection
             : value
       );

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -339,12 +339,29 @@ export const NATIVE = {
   _serializeObject(data: {
     [key: string]: unknown;
   }): { [key: string]: string } {
+
+    // safely handles circular references
+    const safeStringify = (obj) => {
+        let cache = [];
+        const retVal = JSON.stringify(
+            obj,
+            (key, value) =>
+                typeof value === "object" && value !== null
+                    ? cache.includes(value)
+                        ? '[Circular ...]' // Duplicate reference found, discard key
+                        : cache.push(value) && value // Store value in our collection
+                    : value
+        );
+        cache = null;
+        return retVal;
+    };
+    // deserialize
     const serialized: { [key: string]: string } = {};
 
     Object.keys(data).forEach(dataKey => {
       const value = data[dataKey];
       serialized[dataKey] =
-        typeof value === 'string' ? value : JSON.stringify(value);
+        typeof value === 'string' ? value : JSON.safeStringify(value);
     });
 
     return serialized;

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -341,27 +341,29 @@ export const NATIVE = {
   }): { [key: string]: string } {
 
     // safely handles circular references
-    const safeStringify = (obj) => {
-        let cache = [];
-        const retVal = JSON.stringify(
-            obj,
-            (key, value) =>
-                typeof value === "object" && value !== null
-                    ? cache.includes(value)
-                        ? '[Circular ...]' // Duplicate reference found, discard key
-                        : cache.push(value) && value // Store value in our collection
-                    : value
-        );
-        cache = null;
-        return retVal;
+    const safeStringify = (obj: unknown): string => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let cache: any[] = [];
+      const retVal = JSON.stringify(
+        obj,
+        (_key, value) =>
+          typeof value === 'object' && value !== null
+            ? cache.includes(value)
+              ? '[Circular ...]' // Duplicate reference found, discard key
+              : cache.push(value) && value // Store value in our collection
+            : value
+      );
+      cache = [];
+      return retVal;
     };
+
     // deserialize
     const serialized: { [key: string]: string } = {};
 
     Object.keys(data).forEach(dataKey => {
       const value = data[dataKey];
       serialized[dataKey] =
-        typeof value === 'string' ? value : JSON.safeStringify(value);
+        typeof value === 'string' ? value : safeStringify(value);
     });
 
     return serialized;

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -357,7 +357,7 @@ export const NATIVE = {
       return retVal;
     };
 
-    // deserialize
+    // serialize
     const serialized: { [key: string]: string } = {};
 
     Object.keys(data).forEach(dataKey => {

--- a/test/utils/normalize.test.ts
+++ b/test/utils/normalize.test.ts
@@ -1,0 +1,25 @@
+import { convertToNormalizedObject } from '../../src/utils/normalize';
+
+describe('normalize', () => {
+  describe('convertToNormalizedObject', () => {
+    test('output equals input for normalized objects', () => {
+      const actualResult = convertToNormalizedObject({ foo: 'bar' });
+      expect(actualResult).toEqual({ foo: 'bar' });
+    });
+
+    test('converted output is normalized', () => {
+      const actualResult = convertToNormalizedObject({ foo: NaN });
+      expect(actualResult).toEqual({ foo: '[NaN]' });
+    });
+
+    test('converts a value to an object', () => {
+      const actualResult = convertToNormalizedObject('foo');
+      expect(actualResult).toEqual({ value: 'foo' });
+    });
+
+    test('converts null to an object', () => {
+      const actualResult = convertToNormalizedObject(null);
+      expect(actualResult).toEqual({ value: null });
+    });
+  });
+});

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -617,28 +617,4 @@ describe('Tests Native Wrapper', () => {
       expect(SentryCapacitor.fetchNativeDeviceContexts).not.toBeCalled();
     });
   });
-
-  describe('_serializeObject', () => {
-    test('serialize regular object', () => {
-      const subObject = { sub1: 'subObjectValue', sub2: 555 }
-      const givenObject = { root1: 'some value', root2: subObject };
-      const serializedObject = NATIVE._serializeObject(givenObject);
-      const expectedObject = {
-        root1: 'some value',
-        root2: '{"sub1":"subObjectValue","sub2":555}'
-      };
-      expect(serializedObject).toEqual(expectedObject);
-    });
-    test('serialize object with circular references', () => {
-      const subObject: { sub1: string, sub2: any } = { sub1: 'subObjectValue', sub2: undefined }
-      const givenObject = { root1: 'some value', root2: subObject };
-      subObject.sub2 = givenObject;
-      const serializedObject = NATIVE._serializeObject(givenObject);
-      const expectedObject = {
-        root1: 'some value',
-        root2: '{"sub1":"subObjectValue","sub2":{"root1":"some value","root2":"[Circular...]"}}'
-      };
-      expect(serializedObject).toEqual(expectedObject);
-    })
-  })
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -617,4 +617,28 @@ describe('Tests Native Wrapper', () => {
       expect(SentryCapacitor.fetchNativeDeviceContexts).not.toBeCalled();
     });
   });
+
+  describe('_serializeObject', () => {
+    test('serialize regular object', () => {
+      const subObject = { sub1: 'subObjectValue', sub2: 555 }
+      const givenObject = { root1: 'some value', root2: subObject };
+      const serializedObject = NATIVE._serializeObject(givenObject);
+      const expectedObject = {
+        root1: 'some value',
+        root2: '{"sub1":"subObjectValue","sub2":555}'
+      };
+      expect(serializedObject).toEqual(expectedObject);
+    });
+    test('serialize object with circular references', () => {
+      const subObject: { sub1: string, sub2: any } = { sub1: 'subObjectValue', sub2: undefined }
+      const givenObject = { root1: 'some value', root2: subObject };
+      subObject.sub2 = givenObject;
+      const serializedObject = NATIVE._serializeObject(givenObject);
+      const expectedObject = {
+        root1: 'some value',
+        root2: '{"sub1":"subObjectValue","sub2":{"root1":"some value","root2":"[Circular...]"}}'
+      };
+      expect(serializedObject).toEqual(expectedObject);
+    })
+  })
 });


### PR DESCRIPTION
When trying to serialize an object like this

```typescript
const subObject: { sub1: string, sub2: any } = { sub1: 'subObjectValue', sub2: undefined }
const givenObject = { root1: 'some value', root2: subObject };
subObject.sub2 = givenObject;
```

one will get an error like this

```
    TypeError: Converting circular structure to JSON
        --> starting at object with constructor 'Object'
        |     property 'b' -> object with constructor 'Object'
        --- property 'd' closes the circle
        at JSON.stringify (<anonymous>)
```

This PR fixes this behavior. A "flattened" output can be seen in the added [unit test](https://github.com/mlostekk/sentry-capacitor/blob/0eb8660011376c315d80a33c6a2b1b77750e69f0/test/wrapper.test.ts#L632).