### PR TITLE
Fix: Always start Sentry Cocoa on Main Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- (iOS) UI API called on a background thread ([#448](https://github.com/getsentry/sentry-capacitor/pull/448))
+
 ## 0.12.3
 
 ### Fixes

--- a/example/ionic-angular-v5/ios/App/Podfile.lock
+++ b/example/ionic-angular-v5/ios/App/Podfile.lock
@@ -1,0 +1,39 @@
+PODS:
+  - Capacitor (5.0.4):
+    - CapacitorCordova
+  - CapacitorCordova (5.0.4)
+  - Sentry/HybridSDK (8.8.0):
+    - SentryPrivate (= 8.8.0)
+  - SentryCapacitor (0.12.3):
+    - Capacitor
+    - Sentry/HybridSDK (= 8.8.0)
+  - SentryPrivate (8.8.0)
+
+DEPENDENCIES:
+  - "Capacitor (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - "SentryCapacitor (from `../../node_modules/@sentry/capacitor`)"
+
+SPEC REPOS:
+  trunk:
+    - Sentry
+    - SentryPrivate
+
+EXTERNAL SOURCES:
+  Capacitor:
+    :path: "../../node_modules/@capacitor/ios"
+  CapacitorCordova:
+    :path: "../../node_modules/@capacitor/ios"
+  SentryCapacitor:
+    :path: "../../node_modules/@sentry/capacitor"
+
+SPEC CHECKSUMS:
+  Capacitor: d3d4463573438b9fa65326d1f3549da6f4c21634
+  CapacitorCordova: b1fe6bf1f36974a8e4a9044b342d22d49c0996d6
+  Sentry: 927dfb29d18a14d924229a59cc2ad149f43349f2
+  SentryCapacitor: 8721f0ada5dca84617870212988890d857aa8fdc
+  SentryPrivate: 4350d865f898224ab9fa02b37d6ee7fbb623f47e
+
+PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
+
+COCOAPODS: 1.11.3

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -56,7 +56,9 @@ public class SentryCapacitor: CAPPlugin {
                 return event
             }
 
-            SentrySDK.start(options: options)
+            DispatchQueue.main.async { [] in
+                SentrySDK.start(options: options)
+            }
 
             sentryOptions = options
 


### PR DESCRIPTION
We must guarantee that Sentry Cocoa initialises on the Main Thread, usually this is the expected flow that usually happens but there are cases where It'll be initialised on another thread and may lead to a Crash.
This fix guarantees that Sentry Cocoa is always initialised on the main thread

Fixes: #424, #443, #207

Lastly, added the missing pod file for one of the samples, it has no impact on the main code and it's always generated when building.