### PR TITLE
Fix: enableWatchdogTerminationTracking (replaces enableOutOfMemoryTracking) is now properly set on iOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- enableWatchdogTerminationTracking (replaces enableOutOfMemoryTracking) is now properly set on iOS. ([#454](https://github.com/getsentry/sentry-capacitor/pull/454))
+
 ## 0.12.3
 
 ### Fixes

--- a/src/nativeOptions.ts
+++ b/src/nativeOptions.ts
@@ -16,7 +16,8 @@ export function FilterNativeOptions(options: CapacitorOptions): CapacitorOptions
     dsn: options.dsn,
     enabled: options.enabled,
     enableNdkScopeSync: options.enableNdkScopeSync,
-    enableOutOfMemoryTracking: options.enableOutOfMemoryTracking,
+    // eslint-disable-next-line deprecation/deprecation
+    enableWatchdogTerminationTracking: options.enableOutOfMemoryTracking ?? options.enableWatchdogTerminationTracking,
     enableTracing: options.enableTracing,
     environment: options.environment,
     // ignoreErrors: Only available on the JavaScript Layer.

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,6 +43,15 @@ export interface CapacitorOptions
   *
   * @default true
   * */
-  enableOutOfMemoryTracking?: boolean;
+  enableWatchdogTerminationTracking?: boolean;
 
+  /**
+  * Enables Out of Memory Tracking for iOS and macCatalyst.
+  * See the following link for more information and possible restrictions:
+  * https://docs.sentry.io/platforms/apple/guides/ios/configuration/out-of-memory/
+  *
+  * @default true
+  * @deprecated The method will be removed on a major update, instead, use enableWatchdogTerminationTracking for the same result.
+  * */
+  enableOutOfMemoryTracking?: boolean;
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -24,7 +24,7 @@ export function init<O>(
 ): void {
   const finalOptions = {
     enableAutoSessionTracking: true,
-    enableOutOfMemoryTracking: true,
+    enableWatchdogTerminationTracking: true,
     ...passedOptions,
   };
   if (finalOptions.enabled === false ||

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -3,6 +3,31 @@ import type { Instrumenter, StackParser } from '@sentry/types';
 import { FilterNativeOptions } from '../src/nativeOptions';
 
 describe('nativeOptions', () => {
+
+  test('Use value of enableOutOfMemoryTracking on enableWatchdogTerminationTracking when set true', async () => {
+    const nativeOptions = FilterNativeOptions(
+      {
+        enableOutOfMemoryTracking: true
+      });
+    expect(nativeOptions.enableWatchdogTerminationTracking).toBeTruthy();
+  });
+
+  test('Use value of enableOutOfMemoryTracking on enableWatchdogTerminationTracking when set false', async () => {
+    const nativeOptions = FilterNativeOptions(
+      {
+        enableOutOfMemoryTracking: false
+      });
+    expect(nativeOptions.enableWatchdogTerminationTracking).toBeFalsy();
+  });
+
+  test('enableWatchdogTerminationTracking is set when defined', async () => {
+    const nativeOptions = FilterNativeOptions(
+      {
+        enableWatchdogTerminationTracking: true
+      });
+    expect(nativeOptions.enableWatchdogTerminationTracking).toBeTruthy();
+  });
+
   test('invalid types not included', async () => {
     const nativeOptions = FilterNativeOptions(
       {


### PR DESCRIPTION
New implementation of Sentry Cocoa uses `enableWatchdogTerminationTracking` instead of  `enableOutOfMemoryTracking `
This PR fixes the correct value to be sent to the Native SDK, allowing both methods to be used, and also deprecates enableOutOfMemoryTracking to warn users that this feature will be removed on a major version.


Fixes #445