### PR TITLE
Add sentry-angular-ivy to optinal deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,15 @@
   "license": "MIT",
   "peerDependencies": {
     "@capacitor/core": ">=3.0.0",
+    "@sentry/angular-ivy": "7.70.0-beta.1",
     "@sentry/angular": "7.70.0-beta.1",
     "@sentry/react": "7.70.0-beta.1",
     "@sentry/vue": "7.70.0-beta.1"
   },
   "peerDependenciesMeta": {
+    "@sentry/angular-ivy": {
+      "optional": true
+    },
     "@sentry/angular": {
       "optional": true
     },


### PR DESCRIPTION
- related to https://github.com/getsentry/sentry-capacitor/issues/405
- supersedes https://github.com/getsentry/sentry-capacitor/pull/458

Capacitor SDK uses peer deps to enforece supported version of the related Sentry Javascript packages. This is important as mismatched versions can lead to 
unexpected behaviour, mismatched types etc.

Currently the latest angular-ivy package was not included. This pr adds it.
