### PR TITLE
Bump Sentry Java 6.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@
 
 ### Fixes
 
+- op and breadcrumb errors on Android ([#478](https://github.com/getsentry/sentry-capacitor/pull/478))
 - (iOS) UI API called on a background thread ([#448](https://github.com/getsentry/sentry-capacitor/pull/448))
 - enableWatchdogTerminationTracking (replaces enableOutOfMemoryTracking) is now properly set on iOS. ([#454](https://github.com/getsentry/sentry-capacitor/pull/454))
+
+### Dependencies
+
+- Bump Sentry Android SDK to `6.31.0` ([#478](https://github.com/getsentry/sentry-capacitor/pull/478))
+  - [changelog](https://github.com/getsentry/sentry-java/releases/tag/6.31.0)
+  - [diff](https://github.com/getsentry/sentry-java/compare/6.19.0...6.31.0)
 
 ## 0.12.3
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation 'io.sentry:sentry-android:6.19.0'
+    implementation 'io.sentry:sentry-android:6.31.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
This bump include fixes to Hybrid SDKs that fixes the required (now optional) op field from Tracing events and also empty breadcrumb lists.

Fixes #459 and #450