### PR TITLE
Feat: Expose Replay and BrowserTracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Expose Replay and BrowserTracing on `@sentry/capacitor` ([#489](https://github.com/getsentry/sentry-capacitor/pull/489))
+
 ## 0.14.0
 
 ### Features

--- a/example/ionic-angular-v2/.gitignore
+++ b/example/ionic-angular-v2/.gitignore
@@ -1,2 +1,5 @@
 .vscode/
 typings/
+
+# Sentry Auth Token
+.sentryclirc

--- a/example/ionic-angular-v2/package.json
+++ b/example/ionic-angular-v2/package.json
@@ -49,7 +49,7 @@
   "name": "ionic-angular",
   "private": true,
   "scripts": {
-    "build": "ng build && yarn run sentry:sourcemaps",
+    "build": "ionic build && yarn run sentry:sourcemaps",
     "e2e": "ng e2e",
     "lint": "ng lint",
     "ng": "ng",

--- a/example/ionic-angular-v2/package.json
+++ b/example/ionic-angular-v2/package.json
@@ -14,7 +14,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^5.0.0",
-    "@sentry/angular": "7.73.0",
+    "@sentry/angular-ivy": "7.73.0",
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
@@ -33,6 +33,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",
+    "@sentry/cli": "^2.21.2",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
@@ -48,12 +49,14 @@
   "name": "ionic-angular",
   "private": true,
   "scripts": {
-    "build": "ng build",
+    "build": "ng build && yarn run sentry:sourcemaps",
     "e2e": "ng e2e",
     "lint": "ng lint",
     "ng": "ng",
     "start": "ng serve",
-    "test": "ng test"
+    "test": "ng test",
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project sentry-capacitor ./www && sentry-cli sourcemaps upload --org sentry-sdks --project sentry-capacitor ./www",
+    "ng build": "ng build"
   },
   "version": "0.0.1"
 }

--- a/example/ionic-angular-v2/src/app/app.module.ts
+++ b/example/ionic-angular-v2/src/app/app.module.ts
@@ -7,8 +7,7 @@ import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
 
 import * as Sentry from '@sentry/capacitor';
-import { init as sentryAngularInit, createErrorHandler } from '@sentry/angular';
-import { Integrations } from '@sentry/tracing';
+import { init as sentryAngularInit, createErrorHandler } from '@sentry/angular-ivy';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -25,7 +24,7 @@ Sentry.init(
     // Whether SDK should be enabled or not
     enabled: true,
     // Use the tracing integration to see traces and add performance monitoring
-    integrations: [new Integrations.BrowserTracing()],
+    integrations: [new Sentry.BrowserTracing()],
     // A release identifier
     release: '1.0.0',
     // A dist identifier

--- a/example/ionic-angular-v2/yarn.lock
+++ b/example/ionic-angular-v2/yarn.lock
@@ -1571,10 +1571,10 @@
     "@sentry/utils" "7.73.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/angular@7.73.0":
+"@sentry/angular-ivy@7.73.0":
   version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@sentry/angular/-/angular-7.73.0.tgz#9a7e3f3c74586633873350a42709f3a4760d987a"
-  integrity sha512-Fk806JtChbLxMy+4kBp34LwHVHlmiZ6V6lhxLIDV5O4pJ7iqIzTx5u0MjSUfSfOiS2J4HtIcX9jF8fMKB0jEvg==
+  resolved "https://registry.yarnpkg.com/@sentry/angular-ivy/-/angular-ivy-7.73.0.tgz#b09a5e8f8d2ebc8e690dbd3b5a3c8fb7f4944462"
+  integrity sha512-IH/1Giw/pJk38TSb2br8GgbkrQzfDX/blXutErgQophqhjhwo5DSpzD6PDBktrM7JT/xqXKLI8pu8E/2ZSfsNA==
   dependencies:
     "@sentry/browser" "7.73.0"
     "@sentry/types" "7.73.0"
@@ -1594,7 +1594,7 @@
     tslib "^2.4.1 || ^1.9.3"
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor":
-  version "0.13.0-beta.1"
+  version "0.14.0"
   dependencies:
     "@sentry/browser" "7.73.0"
     "@sentry/core" "7.73.0"
@@ -1603,6 +1603,17 @@
     "@sentry/tracing" "7.73.0"
     "@sentry/types" "7.73.0"
     "@sentry/utils" "7.73.0"
+
+"@sentry/cli@^2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.21.2.tgz#89e5633ff48a83d078c76c6997fffd4b68b2da1c"
+  integrity sha512-X1nye89zl+QV3FSuQDGItfM51tW9PQ7ce0TtV/12DgGgTVEgnVp5uvO3wX5XauHvulQzRPzwUL3ZK+yS5bAwCw==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
 
 "@sentry/core@7.73.0":
   version "7.73.0"
@@ -5776,6 +5787,13 @@ node-addon-api@^3.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
+node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1.2.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz"
@@ -6625,6 +6643,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz"
@@ -6681,7 +6704,7 @@ proxy-agent@^5.0.0:
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^5.0.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -7822,6 +7845,11 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tree-kill@1.2.2, tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz"
@@ -8072,6 +8100,11 @@ webdriver-manager@^12.1.7:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webpack-dev-middleware@5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz"
@@ -8200,6 +8233,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/example/ionic-angular-v5/.gitignore
+++ b/example/ionic-angular-v5/.gitignore
@@ -1,2 +1,5 @@
 .vscode/
 typings/
+
+# Sentry Auth Token
+.sentryclirc

--- a/example/ionic-angular-v5/package.json
+++ b/example/ionic-angular-v5/package.json
@@ -14,7 +14,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^5.0.0",
-    "@sentry/angular": "7.73.0",
+    "@sentry/angular-ivy": "7.73.0",
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
@@ -30,6 +30,7 @@
     "@capacitor/cli": "^5.0.0",
     "@ionic/angular-toolkit": "^2.3.0",
     "@ionic/cli": "^6.16.3",
+    "@sentry/cli": "^2.21.2",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",
@@ -48,12 +49,13 @@
   "name": "ionic-angular",
   "private": true,
   "scripts": {
-    "build": "ng build",
+    "build": "ionic build && yarn run sentry:sourcemaps",
     "e2e": "ng e2e",
     "lint": "ng lint",
     "ng": "ng",
     "start": "ng serve",
-    "test": "ng test"
+    "test": "ng test",
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project aspnet-core ./www && sentry-cli sourcemaps upload --org sentry-sdks --project aspnet-core ./www"
   },
   "version": "0.0.1"
 }

--- a/example/ionic-angular-v5/package.json
+++ b/example/ionic-angular-v5/package.json
@@ -55,7 +55,7 @@
     "ng": "ng",
     "start": "ng serve",
     "test": "ng test",
-    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project aspnet-core ./www && sentry-cli sourcemaps upload --org sentry-sdks --project aspnet-core ./www"
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project sentry-capacitor ./www && sentry-cli sourcemaps upload --org sentry-sdks --project sentry-capacitor ./www"
   },
   "version": "0.0.1"
 }

--- a/example/ionic-angular-v5/src/app/app.module.ts
+++ b/example/ionic-angular-v5/src/app/app.module.ts
@@ -4,13 +4,11 @@ import { RouteReuseStrategy } from '@angular/router';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
-import { createErrorHandler, init as sentryAngularInit } from '@sentry/angular';
+import { createErrorHandler, init as sentryAngularInit } from '@sentry/angular-ivy';
 import * as Sentry from '@sentry/capacitor';
-import { Integrations } from '@sentry/tracing';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { Replay } from "@sentry/replay";
 
 // ATTENTION: Change the DSN below with your own to see the events in Sentry. Get one at sentry.io
 Sentry.init(
@@ -25,8 +23,8 @@ Sentry.init(
     enabled: true,
     // Use the tracing integration to see traces and add performance monitoring
     integrations: [
-      new Integrations.BrowserTracing(),
-      new Replay({
+      new Sentry.BrowserTracing(),
+      new Sentry.Replay({
         maskAllText: false,
         blockAllMedia: true,
       }),

--- a/example/ionic-angular-v5/yarn.lock
+++ b/example/ionic-angular-v5/yarn.lock
@@ -1794,10 +1794,10 @@
     "@sentry/utils" "7.73.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/angular@7.73.0":
+"@sentry/angular-ivy@7.73.0":
   version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@sentry/angular/-/angular-7.73.0.tgz#9a7e3f3c74586633873350a42709f3a4760d987a"
-  integrity sha512-Fk806JtChbLxMy+4kBp34LwHVHlmiZ6V6lhxLIDV5O4pJ7iqIzTx5u0MjSUfSfOiS2J4HtIcX9jF8fMKB0jEvg==
+  resolved "https://registry.yarnpkg.com/@sentry/angular-ivy/-/angular-ivy-7.73.0.tgz#b09a5e8f8d2ebc8e690dbd3b5a3c8fb7f4944462"
+  integrity sha512-IH/1Giw/pJk38TSb2br8GgbkrQzfDX/blXutErgQophqhjhwo5DSpzD6PDBktrM7JT/xqXKLI8pu8E/2ZSfsNA==
   dependencies:
     "@sentry/browser" "7.73.0"
     "@sentry/types" "7.73.0"
@@ -1817,7 +1817,7 @@
     tslib "^2.4.1 || ^1.9.3"
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor":
-  version "0.13.0-beta.1"
+  version "0.14.0"
   dependencies:
     "@sentry/browser" "7.73.0"
     "@sentry/core" "7.73.0"
@@ -1826,6 +1826,17 @@
     "@sentry/tracing" "7.73.0"
     "@sentry/types" "7.73.0"
     "@sentry/utils" "7.73.0"
+
+"@sentry/cli@^2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.21.2.tgz#89e5633ff48a83d078c76c6997fffd4b68b2da1c"
+  integrity sha512-X1nye89zl+QV3FSuQDGItfM51tW9PQ7ce0TtV/12DgGgTVEgnVp5uvO3wX5XauHvulQzRPzwUL3ZK+yS5bAwCw==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
 
 "@sentry/core@7.73.0":
   version "7.73.0"
@@ -6098,6 +6109,13 @@ node-addon-api@^3.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
+node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -6947,6 +6965,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -7011,7 +7034,7 @@ proxy-agent@^5.0.0:
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^5.0.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -8176,6 +8199,11 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tree-kill@1.2.2, tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -8453,6 +8481,11 @@ webdriver-manager@^12.1.7:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webpack-dev-middleware@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz#8fc02dba6e72e1d373eca361623d84610f27be7c"
@@ -8581,6 +8614,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-module@^2.0.0:
   version "2.0.1"

--- a/example/ionic-angular/.gitignore
+++ b/example/ionic-angular/.gitignore
@@ -1,2 +1,5 @@
 .vscode/
 typings/
+
+# Sentry Auth Token
+.sentryclirc

--- a/example/ionic-angular/angular.json
+++ b/example/ionic-angular/angular.json
@@ -60,7 +60,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,

--- a/example/ionic-angular/package.json
+++ b/example/ionic-angular/package.json
@@ -14,7 +14,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^5.0.0",
-    "@sentry/angular": "7.73.0",
+    "@sentry/angular-ivy": "7.73.0",
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
@@ -33,6 +33,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",
+    "@sentry/cli": "^2.21.2",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
@@ -48,12 +49,13 @@
   "name": "ionic-angular",
   "private": true,
   "scripts": {
-    "build": "ng build",
+    "build": "ionic build && yarn run sentry:sourcemaps",
     "e2e": "ng e2e",
     "lint": "ng lint",
     "ng": "ng",
     "start": "ng serve",
-    "test": "ng test"
+    "test": "ng test",
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project sentry-capacitor ./www && sentry-cli sourcemaps upload --org sentry-sdks --project sentry-capacitor ./www",
   },
   "version": "0.0.1"
 }

--- a/example/ionic-angular/src/app/app.module.ts
+++ b/example/ionic-angular/src/app/app.module.ts
@@ -1,16 +1,16 @@
-import { ErrorHandler, NgModule } from '@angular/core';
+import { APP_INITIALIZER, ErrorHandler, NgModule } from "@angular/core";
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
-import { createErrorHandler, init as sentryAngularInit } from '@sentry/angular';
+import { Router } from "@angular/router";
+
+import { createErrorHandler, TraceService, routingInstrumentation, init as sentryAngularInit } from '@sentry/angular-ivy';
 import * as Sentry from '@sentry/capacitor';
-import { Integrations } from '@sentry/tracing';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { Replay } from "@sentry/replay";
 
 // ATTENTION: Change the DSN below with your own to see the events in Sentry. Get one at sentry.io
 Sentry.init(
@@ -25,8 +25,8 @@ Sentry.init(
     enabled: true,
     // Use the tracing integration to see traces and add performance monitoring
     integrations: [
-      new Integrations.BrowserTracing(),
-      new Replay({
+      new Sentry.BrowserTracing({routingInstrumentation}),
+      new Sentry.Replay({
         maskAllText: false,
         blockAllMedia: true,
       }),
@@ -62,6 +62,17 @@ Sentry.init(
       provide: ErrorHandler,
       useValue: createErrorHandler(),
     },
+    {
+      provide: TraceService,
+      deps: [Router],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [TraceService],
+      multi: true,
+    },
+
   ],
   bootstrap: [AppComponent]
 })

--- a/example/ionic-angular/yarn.lock
+++ b/example/ionic-angular/yarn.lock
@@ -1644,10 +1644,10 @@
     "@sentry/utils" "7.73.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/angular@7.73.0":
+"@sentry/angular-ivy@7.73.0":
   version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@sentry/angular/-/angular-7.73.0.tgz#9a7e3f3c74586633873350a42709f3a4760d987a"
-  integrity sha512-Fk806JtChbLxMy+4kBp34LwHVHlmiZ6V6lhxLIDV5O4pJ7iqIzTx5u0MjSUfSfOiS2J4HtIcX9jF8fMKB0jEvg==
+  resolved "https://registry.yarnpkg.com/@sentry/angular-ivy/-/angular-ivy-7.73.0.tgz#b09a5e8f8d2ebc8e690dbd3b5a3c8fb7f4944462"
+  integrity sha512-IH/1Giw/pJk38TSb2br8GgbkrQzfDX/blXutErgQophqhjhwo5DSpzD6PDBktrM7JT/xqXKLI8pu8E/2ZSfsNA==
   dependencies:
     "@sentry/browser" "7.73.0"
     "@sentry/types" "7.73.0"
@@ -1667,7 +1667,7 @@
     tslib "^2.4.1 || ^1.9.3"
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor":
-  version "0.13.0-beta.1"
+  version "0.14.0"
   dependencies:
     "@sentry/browser" "7.73.0"
     "@sentry/core" "7.73.0"
@@ -1676,6 +1676,17 @@
     "@sentry/tracing" "7.73.0"
     "@sentry/types" "7.73.0"
     "@sentry/utils" "7.73.0"
+
+"@sentry/cli@^2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.21.2.tgz#89e5633ff48a83d078c76c6997fffd4b68b2da1c"
+  integrity sha512-X1nye89zl+QV3FSuQDGItfM51tW9PQ7ce0TtV/12DgGgTVEgnVp5uvO3wX5XauHvulQzRPzwUL3ZK+yS5bAwCw==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
 
 "@sentry/core@7.73.0":
   version "7.73.0"
@@ -5820,6 +5831,13 @@ node-addon-api@^3.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
+node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
@@ -6650,6 +6668,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -6714,7 +6737,7 @@ proxy-agent@^5.0.0:
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^5.0.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -7843,6 +7866,11 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tree-kill@1.2.2, tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -8098,6 +8126,11 @@ webdriver-manager@^12.1.7:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webpack-dev-middleware@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz#8fc02dba6e72e1d373eca361623d84610f27be7c"
@@ -8226,6 +8259,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export {
   startTransaction,
   withScope,
 } from '@sentry/core';
+export { Replay, BrowserTracing } from '@sentry/browser'
 
 export { SDK_NAME, SDK_VERSION } from './version';
 export { CapacitorOptions } from './options';


### PR DESCRIPTION
Exposes Replay and BrowserTracing that were already bundled by @sentry/browser to @sentry/capacitor so users can refer to a single SDK for those references, instead of importing a sibling SDK or sentry/browser for that
Before:
```javascript
import * as Sentry from '@sentry/capacitor';
import * as SentryBrowser from '@sentry/browser';
Sentry.init(
    integrations: [
      new SentryBrowser.BrowserTracing({routingInstrumentation}),
      new SentryBrowser.Replay({
        maskAllText: false,
        blockAllMedia: true,
      }),
    ],
```

After:
```javascript
import * as Sentry from '@sentry/capacitor';
Sentry.init(
    integrations: [
      new Sentry.BrowserTracing({routingInstrumentation}),
      new Sentry.Replay({
        maskAllText: false,
        blockAllMedia: true,
      }),
    ],
```

Minor changes:
 -Update Samples with Sentry/Angular-ivy (recommended SDK for the latest Angular version) and integrate Sentry/CLI on the Samples.