### PR TITLE
fix: correct the capacitor url replacement

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -11,6 +11,7 @@ import type { CapacitorOptions } from './options';
 import { CapacitorScope } from './scope';
 import { DEFAULT_BUFFER_SIZE, makeNativeTransport } from './transports/native';
 import { makeUtf8TextEncoder } from './transports/TextEncoder';
+import { getCurrentServerUrl } from './utils/webViewUrl';
 import { NATIVE } from './wrapper';
 
 /**
@@ -46,10 +47,15 @@ export function init<O>(
       iteratee: (frame: StackFrame) => {
         if (frame.filename) {
           const isReachableHost = /^https?:\/\//.test(frame.filename);
-          frame.filename = frame.filename
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, no-restricted-globals
-            .replace((window as any).WEBVIEW_SERVER_URL, '')
-            .replace(/^ng:\/\//, '');
+          const serverUrl = getCurrentServerUrl();
+          if (serverUrl) {
+            frame.filename = frame.filename.replace(serverUrl, '');
+          } else {
+            frame.filename = frame.filename.replace(/^https?:\/\/localhost(:\d+)?/, '')
+              .replace(/^capacitor:\/\/localhost(:\d+)?/, '');
+          }
+          frame.filename = frame.filename.replace(/^ng:\/\//, '');
+
           const isNativeFrame = frame.filename === '[native code]' || frame.filename === 'native';
 
           if (!isNativeFrame) {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -46,12 +46,10 @@ export function init<O>(
       iteratee: (frame: StackFrame) => {
         if (frame.filename) {
           const isReachableHost = /^https?:\/\//.test(frame.filename);
-
           frame.filename = frame.filename
-            .replace(/^https?:\/\/localhost(:\d+)?/, '')
-            .replace(/^ng:\/\//, '')
-            .replace(/^capacitor:\/\/localhost(:\d+)?/, '');
-
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, no-restricted-globals
+            .replace((window as any).WEBVIEW_SERVER_URL, '')
+            .replace(/^ng:\/\//, '');
           const isNativeFrame = frame.filename === '[native code]' || frame.filename === 'native';
 
           if (!isNativeFrame) {

--- a/src/utils/webViewUrl.ts
+++ b/src/utils/webViewUrl.ts
@@ -1,0 +1,10 @@
+interface GlobalObject extends Window {
+  WEBVIEW_SERVER_URL?: string;
+};
+
+/**
+ * Return the current webview url if found.
+ */
+export function getCurrentServerUrl(): string | undefined {
+  return (self as GlobalObject).WEBVIEW_SERVER_URL;
+}


### PR DESCRIPTION
Instead of hardcoding the replacement of the Capacitor url for just `https://localhost` and `capacitor://localhost`, use the value on `window.WEBVIEW_SERVER_URL` that Capacitor sets with the proper value based on the user scheme and hostname configuration.

I had to disable some eslint rules for the line, let me know if there is a better approach

closes https://github.com/getsentry/sentry-capacitor/issues/440
closes https://github.com/getsentry/sentry-capacitor/issues/391