### PR TITLE
Rollback changelog for sibling SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 
 ### Dependencies
 
-- Bump JavaScript Sibling SDKs from v7.81.1 to v7.93.0 ([#527](https://github.com/getsentry/sentry-capacitor/pull/527))
-  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7930)
-  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.81.1...7.93.0)
 - Bump Cocoa SDK from v8.8.0 to v8.18.0 ([#526](https://github.com/getsentry/sentry-capacitor/pull/526))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8180)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.8.0...8.18.0)


### PR DESCRIPTION
SDK will be updated back on the next release.

#skip-changelog.