### PR TITLE
fix: disable native sdk if DSN is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Native integration would not properly disable when no DSN was provided ([#584](https://github.com/getsentry/sentry-capacitor/pull/584))
+
 ## 0.16.0
 
 ### Features

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -82,6 +82,8 @@ export const NATIVE = {
       logger.warn(
         'Warning: No DSN was provided. The Sentry SDK will be disabled. Native SDK will also not be initalized.',
       );
+
+      this.enableNative = false;
       return false;
     }
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -163,6 +163,14 @@ describe('Tests Native Wrapper', () => {
         'Note: Native Sentry SDK is disabled.',
       );
     });
+
+    test('sets enableNative: false when dsn is undefined', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: undefined,
+      });
+
+      expect(NATIVE.enableNative).toBe(false);
+    });
   });
 
   describe('sendEnvelope', () => {


### PR DESCRIPTION
When no DSN is provided, the `initNativeSdk` function returns before the `enableNative` option is set. Effectively rendering the option useless.

This causes, the native sdk to still perform the checks of whether the native client is available and if that is not the case, then throws the `NativeClientError`.

A simple reproduction example would be:

```typescript
Sentry.init({
  dsn: undefined,
  enableNative: false,
});

setUser(null);
```

the `setUser` call will throw the NativeClientError.

I chose to set `enableNative` to false regardless of the provided option since the warning message that gets logged when the DSN is not provided states "... Native SDK will also not be initialized.", which should be enough of a hint that the native sdk will not function regardless of the provided `enableNative` unless a DSN is provided.