### PR TITLE
Feat: Add enableAppHangTracking and appHangTimeoutInterval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add enableAppHangTracking to Capacitor Options. ([#602](https://github.com/getsentry/sentry-capacitor/pull/602))
+-Add options for iOS: enableAppHangTracking and appHangTimeoutInterval, allowing users to define the App hang timeout or completly disabling it. ([#602](https://github.com/getsentry/sentry-capacitor/pull/602))
 
 ## 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add enableAppHangTracking to Capacitor Options. ([#602](https://github.com/getsentry/sentry-capacitor/pull/602))
+
 ## 0.16.0
 
 ### Features

--- a/src/nativeOptions.ts
+++ b/src/nativeOptions.ts
@@ -1,3 +1,5 @@
+import { Capacitor } from '@capacitor/core';
+
 import type { CapacitorOptions } from './options';
 
 /**
@@ -34,5 +36,14 @@ export function FilterNativeOptions(options: CapacitorOptions): CapacitorOptions
     tracesSampleRate: options.tracesSampleRate,
     // tunnel: options.tunnel: Only handled on the JavaScript Layer.
     enableCaptureFailedRequests: options.enableCaptureFailedRequests,
+    ...iOSParameters(options)
   };
+}
+
+function iOSParameters(options: CapacitorOptions): CapacitorOptions
+{
+  return Capacitor.getPlatform() === 'ios' ? {
+    enableAppHangTracking: options.enableAppHangTracking,
+    appHangTimeoutInterval: options.appHangTimeoutInterval
+  } : {}
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -57,7 +57,29 @@ export interface BaseCapacitorOptions{
    *
    * @default false
    */
+
   enableCaptureFailedRequests?: boolean;
+  /**
+   * When enabled, the SDK tracks when the application stops responding for a specific amount of
+   * time defined by the `appHangTimeoutInterval` option.
+   *
+   * iOS only
+   *
+   * @default true
+   */
+  enableAppHangTracking?: boolean;
+
+  /**
+   * The minimum amount of time an app should be unresponsive to be classified as an App Hanging.
+   * The actual amount may be a little longer.
+   * Avoid using values lower than 100ms, which may cause a lot of app hangs events being transmitted.
+   * Value should be in seconds.
+   *
+   * iOS only
+   *
+   * @default 2
+   */
+  appHangTimeoutInterval?: number;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -57,7 +57,6 @@ export interface BaseCapacitorOptions{
    *
    * @default false
    */
-
   enableCaptureFailedRequests?: boolean;
   /**
    * When enabled, the SDK tracks when the application stops responding for a specific amount of

--- a/src/options.ts
+++ b/src/options.ts
@@ -58,6 +58,7 @@ export interface BaseCapacitorOptions{
    * @default false
    */
   enableCaptureFailedRequests?: boolean;
+
   /**
    * When enabled, the SDK tracks when the application stops responding for a specific amount of
    * time defined by the `appHangTimeoutInterval` option.


### PR DESCRIPTION
This feature allow users to disable or increase the time of the app hang events.

Without it, Sentry will create events similar to the following one when the app hangs the UI:
https://sentry-sdks.sentry.io/issues/5080073190/events/018e7e8767624078b7fe1422b415231d

by disabling enableAppHang, Sentry will no longer create the hang events.

Close #596