### PR TITLE
Bump: Downgrade Sentry cocoa to 8.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Dependencies
 
-- Bump Cocoa SDK from v8.18.0 to v8.22.2 ([#555](https://github.com/getsentry/sentry-capacitor/pull/555), [#604](https://github.com/getsentry/sentry-capacitor/pull/604))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8222)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.18.0...8.22.2)
+- Bump Cocoa SDK from v8.18.0 to v8.21.0 ([#605](https://github.com/getsentry/sentry-capacitor/pull/605))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8210)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.18.0...8.21.0)
 - Bump Android SDK from v6.34.0 to v7.6.0 ([#544](https://github.com/getsentry/sentry-capacitor/pull/544))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#760)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.34.0...7.6.0)

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
 
-  s.dependency 'Sentry/HybridSDK', '8.22.2'
+  s.dependency 'Sentry/HybridSDK', '8.21.0'
   s.dependency 'Capacitor'
 
   if File.exist?('../../@capacitor/core/package.json') == false

--- a/example/ionic-angular-v2/package.json
+++ b/example/ionic-angular-v2/package.json
@@ -55,6 +55,7 @@
     "ng": "ng",
     "start": "ng serve",
     "test": "ng test",
+    "bump:sample-pod": "cd ios/App && pod install",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project sentry-capacitor ./www && sentry-cli sourcemaps upload --org sentry-sdks --project sentry-capacitor ./www"
   },
   "version": "0.0.1"

--- a/example/ionic-angular-v5/ios/App/Podfile.lock
+++ b/example/ionic-angular-v5/ios/App/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - CapacitorCordova (5.5.1)
   - Sentry/HybridSDK (8.21.0):
     - SentryPrivate (= 8.21.0)
-  - SentryCapacitor (0.16.4):
+  - SentryCapacitor (0.16.0):
     - Capacitor
     - Sentry/HybridSDK (= 8.21.0)
   - SentryPrivate (8.21.0)
@@ -31,7 +31,7 @@ SPEC CHECKSUMS:
   Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
   CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
   Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  SentryCapacitor: a2d752746223f51c6c703cb072a5626fb07925eb
+  SentryCapacitor: cbeaee20f9e7d2b621a62d6d388cb81447c8e420
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800

--- a/example/ionic-angular-v5/ios/App/Podfile.lock
+++ b/example/ionic-angular-v5/ios/App/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Capacitor (5.5.1):
     - CapacitorCordova
   - CapacitorCordova (5.5.1)
-  - Sentry/HybridSDK (8.18.0):
-    - SentryPrivate (= 8.18.0)
-  - SentryCapacitor (0.15.1):
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
+  - SentryCapacitor (0.16.4):
     - Capacitor
-    - Sentry/HybridSDK (= 8.18.0)
-  - SentryPrivate (8.18.0)
+    - Sentry/HybridSDK (= 8.21.0)
+  - SentryPrivate (8.21.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -30,9 +30,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
   CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
-  Sentry: 8984a4ffb2b9bd2894d74fb36e6f5833865bc18e
-  SentryCapacitor: 5c27da09956d89b0ba715071f6a37c137d9aea50
-  SentryPrivate: 2f0c9ba4c3fc993f70eab6ca95673509561e0085
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  SentryCapacitor: a2d752746223f51c6c703cb072a5626fb07925eb
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 

--- a/example/ionic-angular-v5/package.json
+++ b/example/ionic-angular-v5/package.json
@@ -55,6 +55,7 @@
     "ng": "ng",
     "start": "ng serve",
     "test": "ng test",
+    "bump:sample-pod": "cd ios/App && pod install",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project capacitor ./www && sentry-cli sourcemaps upload --org sentry-sdks --project capacitor ./www"
   },
   "version": "0.0.1"

--- a/example/ionic-angular/package.json
+++ b/example/ionic-angular/package.json
@@ -56,6 +56,7 @@
     "ng": "ng",
     "start": "ng serve",
     "test": "ng test",
+    "bump:sample-pod": "cd ios/App && pod install",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org sentry-sdks --project sentry-capacitor ./www && sentry-cli sourcemaps upload --org sentry-sdks --project sentry-capacitor ./www"
   },
   "version": "0.0.1"

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
     - Capacitor
   - Sentry/HybridSDK (8.21.0):
     - SentryPrivate (= 8.21.0)
-  - SentryCapacitor (0.16.4):
+  - SentryCapacitor (0.16.0):
     - Capacitor
     - Sentry/HybridSDK (= 8.21.0)
   - SentryPrivate (8.21.0)
@@ -55,7 +55,7 @@ SPEC CHECKSUMS:
   CapacitorKeyboard: ce5e01064cf57a2c05b32565310713b7fe6cc6f9
   CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
   Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  SentryCapacitor: a2d752746223f51c6c703cb072a5626fb07925eb
+  SentryCapacitor: cbeaee20f9e7d2b621a62d6d388cb81447c8e420
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
 
 PODFILE CHECKSUM: a972544de6bcfa1a17161b0b4ef85e6ee7586f79

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -1,0 +1,63 @@
+PODS:
+  - Capacitor (5.6.0):
+    - CapacitorCordova
+  - CapacitorApp (5.0.6):
+    - Capacitor
+  - CapacitorCordova (5.6.0)
+  - CapacitorHaptics (5.0.6):
+    - Capacitor
+  - CapacitorKeyboard (5.0.7):
+    - Capacitor
+  - CapacitorStatusBar (5.0.6):
+    - Capacitor
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
+  - SentryCapacitor (0.16.4):
+    - Capacitor
+    - Sentry/HybridSDK (= 8.21.0)
+  - SentryPrivate (8.21.0)
+
+DEPENDENCIES:
+  - "Capacitor (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
+  - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
+  - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
+  - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
+  - "SentryCapacitor (from `../../node_modules/@sentry/capacitor`)"
+
+SPEC REPOS:
+  trunk:
+    - Sentry
+    - SentryPrivate
+
+EXTERNAL SOURCES:
+  Capacitor:
+    :path: "../../node_modules/@capacitor/ios"
+  CapacitorApp:
+    :path: "../../node_modules/@capacitor/app"
+  CapacitorCordova:
+    :path: "../../node_modules/@capacitor/ios"
+  CapacitorHaptics:
+    :path: "../../node_modules/@capacitor/haptics"
+  CapacitorKeyboard:
+    :path: "../../node_modules/@capacitor/keyboard"
+  CapacitorStatusBar:
+    :path: "../../node_modules/@capacitor/status-bar"
+  SentryCapacitor:
+    :path: "../../node_modules/@sentry/capacitor"
+
+SPEC CHECKSUMS:
+  Capacitor: ebfc16cdb8116d04c101686b080342872da42d43
+  CapacitorApp: 024e1b1bea5f883d79f6330d309bc441c88ad04a
+  CapacitorCordova: 931b48fcdbc9bc985fc2f16cec9f77c794a27729
+  CapacitorHaptics: 1fffc1217c7e64a472d7845be50fb0c2f7d4204c
+  CapacitorKeyboard: ce5e01064cf57a2c05b32565310713b7fe6cc6f9
+  CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  SentryCapacitor: a2d752746223f51c6c703cb072a5626fb07925eb
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
+
+PODFILE CHECKSUM: a972544de6bcfa1a17161b0b4ef85e6ee7586f79
+
+COCOAPODS: 1.14.3

--- a/example/ionic-vue3/package.json
+++ b/example/ionic-vue3/package.json
@@ -11,6 +11,7 @@
     "sync": "ionic cap copy & ionic cap sync",
     "ios": "ionic cap open ios",
     "android": "ionic cap open android",
+    "bump:sample-pod": "cd ios/App && pod install",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,7 +12,7 @@ end
 target 'Plugin' do
   capacitor_pods
 
-  pod 'Sentry/HybridSDK', '8.18.0'
+  pod 'Sentry/HybridSDK', '8.21.0'
 end
 
 target 'PluginTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - Capacitor (5.5.1):
     - CapacitorCordova
   - CapacitorCordova (5.5.1)
-  - Sentry/HybridSDK (8.18.0):
-    - SentryPrivate (= 8.18.0)
-  - SentryPrivate (8.18.0)
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
+  - SentryPrivate (8.21.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Sentry/HybridSDK (= 8.18.0)
+  - Sentry/HybridSDK (= 8.21.0)
 
 SPEC REPOS:
   trunk:
@@ -25,9 +25,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
   CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
-  Sentry: 8984a4ffb2b9bd2894d74fb36e6f5833865bc18e
-  SentryPrivate: 2f0c9ba4c3fc993f70eab6ca95673509561e0085
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
 
-PODFILE CHECKSUM: 752f62ed07b192beb5be59e6b9f32d127267c66c
+PODFILE CHECKSUM: 6d05c518e9f9e84fa14f2f52d1a6d0939d24afca
 
 COCOAPODS: 1.14.3

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/getsentry/sentry-capacitor"
   },
-  "version": "0.16.4",
+  "version": "0.16.0",
   "description": "Official Sentry SDK for Capacitor",
   "types": "dist/esm/index.d.ts",
   "main": "dist/build/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/getsentry/sentry-capacitor"
   },
-  "version": "0.16.0",
+  "version": "0.16.4",
   "description": "Official Sentry SDK for Capacitor",
   "types": "dist/esm/index.d.ts",
   "main": "dist/build/index.js",
@@ -23,10 +23,10 @@
     "swiftlint": "node-swiftlint",
     "prepack": "yarn run build",
     "postinstall": "node scripts/check-siblings.js",
-    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install && yarn build && npx cap sync",
-    "bump:v3": "cd example/ionic-angular && yalc add @sentry/capacitor && yalc add broken_module && yarn install && yarn build && npx cap sync",
-    "bump:v2": "cd example/ionic-angular-v2 && yalc add @sentry/capacitor && yarn install && yarn build && npx cap sync",
-    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install && ionic build && npx cap sync",
+    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v3": "cd example/ionic-angular && yalc add @sentry/capacitor && yalc add broken_module && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:v2": "cd example/ionic-angular-v2 && yalc add @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install && ionic build && yarn run bump:sample-pod && npx cap sync",
     "bump:samples": "yalc publish && yarn run bump:v5 && yarn run bump:v3 && yarn run bump:v2 && yarn run bump:sample-vue"
   },
   "keywords": [


### PR DESCRIPTION
Version 8.22.2/8.22.1/8.22.0 aren't working with HybridSDKs at the moment and a fix is expected soon, in the meantime we'll bump the SDK to a lower version, not being a downgrade to the users since the latest released version had a lower version for Sentry Cocoa.

This PR also adds an extra script for updating the pod files from the Samples.