### PR TITLE
Fix: Deprecated warnings

### DIFF
--- a/example/ionic-angular-v5/ios/App/Podfile.lock
+++ b/example/ionic-angular-v5/ios/App/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - CapacitorCordova (5.5.1)
   - Sentry/HybridSDK (8.21.0):
     - SentryPrivate (= 8.21.0)
-  - SentryCapacitor (0.16.0):
+  - SentryCapacitor (0.17.0):
     - Capacitor
     - Sentry/HybridSDK (= 8.21.0)
   - SentryPrivate (8.21.0)
@@ -31,9 +31,9 @@ SPEC CHECKSUMS:
   Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
   CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
   Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  SentryCapacitor: cbeaee20f9e7d2b621a62d6d388cb81447c8e420
+  SentryCapacitor: eab7128c7c9558bfca219d1d11dd7aed74b1a01f
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -172,7 +172,7 @@ public class SentryCapacitor: CAPPlugin {
 
             contexts["context"] = context
 
-            call.resolve(contexts as PluginResultData)
+            call.resolve(contexts as PluginCallResultData)
         }
     }
 


### PR DESCRIPTION
This PR fixes some deprecated warnings from both Sentry Native and Capacitor dependency.

No break changes were introduced with this PR.

#skip-changelog