### PR TITLE
Ref: Run sample update concurrently

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: yalc-package
-          path: .yalc # Path to yalc directory where the package is published
+          path: ~/.yalc # Path to yalc directory where the package is published
 
 
     outputs:
@@ -134,7 +134,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: yalc-package
-          path: ${{ matrix.path }}/.yalc # Ensure this path matches where yalc expects to find the package
+          path: ~/.yalc # Ensure this path matches where yalc expects to find the package
 
       - name: Publish test broken node.
         working-directory: example/broken_node_module

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -77,7 +77,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Publish package locally
         run: |
-          yarn  global add yalc
+          yarn global add yalc
           yalc publish
 
       - name: Upload yalc package
@@ -85,7 +85,6 @@ jobs:
         with:
           name: yalc-package
           path: ~/.yalc # Path to yalc directory where the package is published
-
 
     outputs:
       # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -82,11 +82,11 @@ jobs:
       - name: Update SDK & build samples
         run: |
           yalc publish &&
-          yarn run bump:v6 >  read input && echo "[sample V6] $input";  &
-          yarn run bump:v5 >  read input && echo "[sample V5] $input";  &
-          yarn run bump:v4 >  read input && echo "[sample V4] $input"; &
-          yarn run bump:v3 >  read input && echo "[sample V3] $input"; &
-          yarn run bump:sample-vue >  read input && echo "[sample VUE] $input"; &
+          { yarn run bump:v6 >  read input && echo "[sample V6] $input"; } &
+          { yarn run bump:v5 >  read input && echo "[sample V5] $input"; } &
+          { yarn run bump:v4 >  read input && echo "[sample V4] $input"; } &
+          { yarn run bump:v3 >  read input && echo "[sample V3] $input"; } &
+          { yarn run bump:sample-vue >  read input && echo "[sample VUE] $input"; } &
           wait
 
   job_unit_test:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -36,84 +36,12 @@ jobs:
         with:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}
-      - name: Install Yarn
-        run: npm install -g yarn@1.22.22
 
       - name: Install dependencies
         if: steps.cache_dependencies.outputs.cache-hit == ''
         run: yarn install
     outputs:
       dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}
-
-  job_sample_test:
-    name: Sample Build Test
-    needs: job_build
-    continue-on-error: true
-    timeout-minutes: 30
-    # macos required for the xcode build.
-    runs-on: macos-latest
-    steps:
-      - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
-      - name: Check dependency cache
-        uses: actions/cache@v3.3.3
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_build.outputs.dependency_cache_key }}
-      - name: Check build cache
-        uses: actions/cache@v3.3.3
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-      - name: Install yalc
-        run: yarn  global add yalc
-      - name: Install Ionic
-        run: yarn  global add @ionic/cli
-      - name: Install Packages
-        run: yarn install
-      - name: Publish test broken node.
-        working-directory: example/broken_node_module
-        run: |
-          yarn install
-          yarn build
-          yalc publish
-      - name: Update SDK & build samples
-        run: |
-          yalc publish &&
-          {
-            yarn run bump:v6 | sed 's/^/[sample V6] /' &
-            yarn run bump:v5 | sed 's/^/[sample V5] /' &
-            yarn run bump:v4 | sed 's/^/[sample V4] /' &
-            yarn run bump:v3 | sed 's/^/[sample V3] /' &
-            yarn run bump:sample-vue | sed 's/^/[sample VUE] /' &
-          } | tee >(cat) &
-          wait
-
-  job_unit_test:
-    name: Test
-    needs: job_build
-    continue-on-error: true
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
-      - name: Check dependency cache
-        uses: actions/cache@v3.3.3
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_build.outputs.dependency_cache_key }}
-      - name: Check build cache
-        uses: actions/cache@v3.3.3
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-      - name: Run tests
-        run: yarn test
 
   job_build:
     name: Build
@@ -147,10 +75,99 @@ jobs:
       - name: Check if yarn.lock is dirty
         if: steps.cache_built_packages.outputs.cache-hit == ''
         run: yarn install --frozen-lockfile
+      - name: Publish package locally
+        run: |
+          yarn  global add yalc
+          yalc publish
+
+      - name: Upload yalc package
+        uses: actions/upload-artifact@v3
+        with:
+          name: yalc-package
+          path: .yalc # Path to yalc directory where the package is published
+
+
     outputs:
       # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on
       # `job_build` can't see `job_install_deps` and what it returned)
       dependency_cache_key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
+
+  job_sample_test:
+    name: Sample Build Test
+    needs: job_build
+    build_variations:
+      # macos required for the xcode build.
+      runs-on: macos-latest
+      strategy:
+        matrix:
+          bump: ['v3', 'v4', 'v5', 'v6', 'vue']
+          path:
+            - 'example/ionic-angular-v3'
+            - 'example/ionic-angular-v4'
+            - 'example/ionic-angular-v5'
+            - 'example/ionic-angular-v6'
+            - 'example/ionic-vue3'
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+      - name: Check dependency cache
+        uses: actions/cache@v3.3.3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v3.3.3
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Install yalc
+        run: yarn  global add yalc
+      - name: Install Ionic
+        run: yarn  global add @ionic/cli
+
+      - name: Download Sentry Capacitor package
+        uses: actions/download-artifact@v3
+        working-directory: ${{ matrix.path }}
+        with:
+          name: yalc-package
+          path: .yalc # Ensure this path matches where yalc expects to find the package
+
+      - name: Publish test broken node.
+        working-directory: example/broken_node_module
+        run: |
+          yarn install
+          yarn build
+          yalc publish
+
+      - name: Build Sample ${{ matrix.bump }}
+        working-directory: ${{ matrix.path }}
+        run: yarn run bump:${{ matrix.bump }}
+
+  job_unit_test:
+    name: Test
+    needs: job_build
+    continue-on-error: true
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+      - name: Check dependency cache
+        uses: actions/cache@v3.3.3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v3.3.3
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Run tests
+        run: yarn test
 
   job_artifacts:
     name: Upload Artifacts

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}
+      - name: Install Yarn
+        run: npm install -g yarn@1.22.22
+
       - name: Install dependencies
         if: steps.cache_dependencies.outputs.cache-hit == ''
         run: yarn install

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -99,13 +99,17 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        bump: ['v3', 'v4', 'v5', 'v6', 'vue']
-        path:
-          - 'example/ionic-angular-v3'
-          - 'example/ionic-angular-v4'
-          - 'example/ionic-angular-v5'
-          - 'example/ionic-angular-v6'
-          - 'example/ionic-vue3'
+        include:
+          - bump: 'v3'
+            path: 'example/ionic-angular-v3'
+          - bump: 'v4'
+            path: 'example/ionic-angular-v4'
+          - bump: 'v5'
+            path: 'example/ionic-angular-v5'
+          - bump: 'v6'
+            path: 'example/ionic-angular-v6'
+          - bump: 'vue'
+            path: 'example/ionic-vue3'
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v3

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -101,15 +101,10 @@ jobs:
       matrix:
         include:
           - bump: 'v3'
-            path: 'example/ionic-angular-v3'
           - bump: 'v4'
-            path: 'example/ionic-angular-v4'
           - bump: 'v5'
-            path: 'example/ionic-angular-v5'
           - bump: 'v6'
-            path: 'example/ionic-angular-v6'
           - bump: 'vue'
-            path: 'example/ionic-vue3'
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v3
@@ -144,7 +139,6 @@ jobs:
           yalc publish
 
       - name: Build Sample ${{ matrix.bump }}
-        working-directory:
         run: yarn run bump:${{ matrix.bump }}
 
   job_unit_test:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -80,7 +80,14 @@ jobs:
           yarn build
           yalc publish
       - name: Update SDK & build samples
-        run: yarn bump:samples
+        run: |
+          yalc publish &&
+          yarn run bump:v6 &
+          yarn run bump:v5 &
+          yarn run bump:v4 &
+          yarn run bump:v3 &
+          yarn run bump:sample-vue &
+          wait
 
   job_unit_test:
     name: Test

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -82,11 +82,11 @@ jobs:
       - name: Update SDK & build samples
         run: |
           yalc publish &&
-          yarn run bump:v6 &
-          yarn run bump:v5 &
-          yarn run bump:v4 &
-          yarn run bump:v3 &
-          yarn run bump:sample-vue &
+          yarn run bump:v6 >  read input && echo "[sample V6] $input";  &
+          yarn run bump:v5 >  read input && echo "[sample V5] $input";  &
+          yarn run bump:v4 >  read input && echo "[sample V4] $input"; &
+          yarn run bump:v3 >  read input && echo "[sample V3] $input"; &
+          yarn run bump:sample-vue >  read input && echo "[sample VUE] $input"; &
           wait
 
   job_unit_test:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -144,7 +144,6 @@ jobs:
           yalc publish
 
       - name: Build Sample ${{ matrix.bump }}
-        working-directory: ${{ matrix.path }}
         run: yarn run bump:${{ matrix.bump }}
 
   job_unit_test:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -82,11 +82,13 @@ jobs:
       - name: Update SDK & build samples
         run: |
           yalc publish &&
-          { yarn run bump:v6 >  read input && echo "[sample V6] $input"; } &
-          { yarn run bump:v5 >  read input && echo "[sample V5] $input"; } &
-          { yarn run bump:v4 >  read input && echo "[sample V4] $input"; } &
-          { yarn run bump:v3 >  read input && echo "[sample V3] $input"; } &
-          { yarn run bump:sample-vue >  read input && echo "[sample VUE] $input"; } &
+          {
+            yarn run bump:v6 | sed 's/^/[sample V6] /' &
+            yarn run bump:v5 | sed 's/^/[sample V5] /' &
+            yarn run bump:v4 | sed 's/^/[sample V4] /' &
+            yarn run bump:v3 | sed 's/^/[sample V3] /' &
+            yarn run bump:sample-vue | sed 's/^/[sample VUE] /' &
+          } | tee >(cat) &
           wait
 
   job_unit_test:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -104,7 +104,7 @@ jobs:
           - bump: 'v4'
           - bump: 'v5'
           - bump: 'v6'
-          - bump: 'vue'
+          - bump: 'sample-vue'
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v3

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -95,18 +95,17 @@ jobs:
   job_sample_test:
     name: Sample Build Test
     needs: job_build
-    build_variations:
-      # macos required for the xcode build.
-      runs-on: macos-latest
-      strategy:
-        matrix:
-          bump: ['v3', 'v4', 'v5', 'v6', 'vue']
-          path:
-            - 'example/ionic-angular-v3'
-            - 'example/ionic-angular-v4'
-            - 'example/ionic-angular-v5'
-            - 'example/ionic-angular-v6'
-            - 'example/ionic-vue3'
+    # macos required for the xcode build.
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        bump: ['v3', 'v4', 'v5', 'v6', 'vue']
+        path:
+          - 'example/ionic-angular-v3'
+          - 'example/ionic-angular-v4'
+          - 'example/ionic-angular-v5'
+          - 'example/ionic-angular-v6'
+          - 'example/ionic-vue3'
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v3
@@ -129,10 +128,9 @@ jobs:
 
       - name: Download Sentry Capacitor package
         uses: actions/download-artifact@v3
-        working-directory: ${{ matrix.path }}
         with:
           name: yalc-package
-          path: .yalc # Ensure this path matches where yalc expects to find the package
+          path: ${{ matrix.path }}/.yalc # Ensure this path matches where yalc expects to find the package
 
       - name: Publish test broken node.
         working-directory: example/broken_node_module

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -144,6 +144,7 @@ jobs:
           yalc publish
 
       - name: Build Sample ${{ matrix.bump }}
+        working-directory:
         run: yarn run bump:${{ matrix.bump }}
 
   job_unit_test:

--- a/example/ionic-angular-v3/package.json
+++ b/example/ionic-angular-v3/package.json
@@ -30,7 +30,7 @@
     "@capacitor/cli": "^3.9.0",
     "@ionic/angular-toolkit": "^2.3.0",
     "@ionic/cli": "^6.16.3",
-    "@sentry/cli": "^2.21.2",I am an error
+    "@sentry/cli": "^2.21.2",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",

--- a/example/ionic-angular-v3/package.json
+++ b/example/ionic-angular-v3/package.json
@@ -30,7 +30,7 @@
     "@capacitor/cli": "^3.9.0",
     "@ionic/angular-toolkit": "^2.3.0",
     "@ionic/cli": "^6.16.3",
-    "@sentry/cli": "^2.21.2",
+    "@sentry/cli": "^2.21.2",I am an error
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "swiftlint": "node-swiftlint",
     "prepack": "yarn run build",
     "postinstall": "node scripts/check-siblings.js",
-    "bump:v6": "cd example/ionic-angular-v6 && yalc add @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install && ionic build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v6": "cd example/ionic-angular-v6 && yalc add @sentry/capacitor && yarn install --mutex network && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install --mutex network && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install --mutex network && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install --mutex network && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install --mutex network && ionic build && yarn run bump:sample-pod && npx cap sync",
     "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "swiftlint": "node-swiftlint",
     "prepack": "yarn run build",
     "postinstall": "node scripts/check-siblings.js",
-    "bump:v6": "cd example/ionic-angular-v6 && yalc link @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v5": "cd example/ionic-angular-v5 && yalc link @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v4": "cd example/ionic-angular-v4 && yalc link @sentry/capacitor && yalc add broken_module && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:v3": "cd example/ionic-angular-v3 && yalc link @sentry/capacitor && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:sample-vue": "cd example/ionic-vue3 && yalc link @sentry/capacitor && yarn install && ionic build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v6": "cd example/ionic-angular-v6 && yalc link @sentry/capacitor && yarn install --check-files && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v5": "cd example/ionic-angular-v5 && yalc link @sentry/capacitor && yarn install --check-files && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v4": "cd example/ionic-angular-v4 && yalc link @sentry/capacitor && yalc add broken_module && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:v3": "cd example/ionic-angular-v3 && yalc link @sentry/capacitor && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:sample-vue": "cd example/ionic-vue3 && yalc link @sentry/capacitor && yarn install --check-files && ionic build && yarn run bump:sample-pod && npx cap sync",
     "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install --check-files && ionic build && yarn run bump:sample-pod && npx cap sync",
-    "bump:samples": "yalc publish && yarn run bump:v6 && yarn run bump:v5 && yarn run bump:v4 && yarn run bump:v3 && yarn run bump:sample-vue"
+    "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [
     "capacitor",
@@ -80,6 +80,7 @@
     "@sentry-internal/typescript": "7.114.0",
     "@sentry/wizard": "3.21.0",
     "@types/jest": "^26.0.15",
+    "concurrently": "^8.2.2",
     "eslint": "^7.13.0",
     "jest": "^26.6.3",
     "prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bump:v4": "cd example/ionic-angular-v4 && yalc link @sentry/capacitor && yalc add broken_module && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:v3": "cd example/ionic-angular-v3 && yalc link @sentry/capacitor && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:sample-vue": "cd example/ionic-vue3 && yalc link @sentry/capacitor && yarn install --check-files && ionic build && yarn run bump:sample-pod && npx cap sync",
-    "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
+    "bump:samples": "yalc publish && yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [
     "capacitor",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "swiftlint": "node-swiftlint",
     "prepack": "yarn run build",
     "postinstall": "node scripts/check-siblings.js",
-    "bump:v6": "cd example/ionic-angular-v6 && yalc add @sentry/capacitor && yarn install --mutex network && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install --mutex network && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install --mutex network && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install --mutex network && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install --mutex network && ionic build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v6": "cd example/ionic-angular-v6 && yalc link @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v5": "cd example/ionic-angular-v5 && yalc link @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v4": "cd example/ionic-angular-v4 && yalc link @sentry/capacitor && yalc add broken_module && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:v3": "cd example/ionic-angular-v3 && yalc link @sentry/capacitor && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:sample-vue": "cd example/ionic-vue3 && yalc link @sentry/capacitor && yarn install && ionic build && yarn run bump:sample-pod && npx cap sync",
     "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install --check-files && ionic build && yarn run bump:sample-pod && npx cap sync",
-    "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
+    "bump:samples": "yalc publish && yarn run bump:v6 && yarn run bump:v5 && yarn run bump:v4 && yarn run bump:v3 && yarn run bump:sample-vue"
   },
   "keywords": [
     "capacitor",
@@ -80,7 +80,6 @@
     "@sentry-internal/typescript": "7.114.0",
     "@sentry/wizard": "3.21.0",
     "@types/jest": "^26.0.15",
-    "concurrently": "^8.2.2",
     "eslint": "^7.13.0",
     "jest": "^26.6.3",
     "prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "swiftlint": "node-swiftlint",
     "prepack": "yarn run build",
     "postinstall": "node scripts/check-siblings.js",
-    "bump:v6": "cd example/ionic-angular-v6 && yalc add @sentry/capacitor && yarn install --check-files && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install --check-files && yarn build && yarn run bump:sample-pod && npx cap sync",
-    "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
-    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install --check-files && ionic build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v6": "cd example/ionic-angular-v6 && yalc add @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v5": "cd example/ionic-angular-v5 && yalc add @sentry/capacitor && yarn install && yarn build && yarn run bump:sample-pod && npx cap sync",
+    "bump:v4": "cd example/ionic-angular-v4 && yalc add @sentry/capacitor && yalc add broken_module && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:v3": "cd example/ionic-angular-v3 && yalc add @sentry/capacitor && yarn install && yarn run build && yarn bump:sample-pod && npx cap sync",
+    "bump:sample-vue": "cd example/ionic-vue3 && yalc add @sentry/capacitor && yarn install && ionic build && yarn run bump:sample-pod && npx cap sync",
     "bump:samples": "yalc publish &&  yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,13 +256,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime@^7.21.0":
-  version "7.24.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
-  integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -1940,21 +1933,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-concurrently@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-8.2.2.tgz#353141985c198cfa5e4a3ef90082c336b5851784"
-  integrity sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==
-  dependencies:
-    chalk "^4.1.2"
-    date-fns "^2.30.0"
-    lodash "^4.17.21"
-    rxjs "^7.8.1"
-    shell-quote "^1.8.1"
-    spawn-command "0.0.2"
-    supports-color "^8.1.1"
-    tree-kill "^1.2.2"
-    yargs "^17.7.2"
-
 convert-source-map@^1.4.0, convert-source-map@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
@@ -2026,13 +2004,6 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
-
-date-fns@^2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
 
 debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
@@ -4064,7 +4035,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@4.x, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4738,11 +4709,6 @@ recast@^0.23.4:
     source-map "~0.6.1"
     tslib "^2.0.1"
 
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -4906,13 +4872,6 @@ rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.8.1:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
-  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
-  dependencies:
-    tslib "^2.1.0"
-
 safe-array-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c"
@@ -5046,11 +5005,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
-  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
-
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -5171,11 +5125,6 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
-
-spawn-command@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
-  integrity sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==
 
 spdx-correct@^3.0.0:
   version "3.2.0"
@@ -5360,13 +5309,6 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -6027,7 +5969,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.2.1, yargs@^17.7.2:
+yargs@^17.2.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,6 +256,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/runtime@^7.21.0":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
+  integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -1933,6 +1940,21 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+concurrently@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-8.2.2.tgz#353141985c198cfa5e4a3ef90082c336b5851784"
+  integrity sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==
+  dependencies:
+    chalk "^4.1.2"
+    date-fns "^2.30.0"
+    lodash "^4.17.21"
+    rxjs "^7.8.1"
+    shell-quote "^1.8.1"
+    spawn-command "0.0.2"
+    supports-color "^8.1.1"
+    tree-kill "^1.2.2"
+    yargs "^17.7.2"
+
 convert-source-map@^1.4.0, convert-source-map@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
@@ -2004,6 +2026,13 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
@@ -4035,7 +4064,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@4.x, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.7.0:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4709,6 +4738,11 @@ recast@^0.23.4:
     source-map "~0.6.1"
     tslib "^2.0.1"
 
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -4872,6 +4906,13 @@ rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-array-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c"
@@ -5005,6 +5046,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-quote@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
+  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -5125,6 +5171,11 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+spawn-command@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
+  integrity sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==
 
 spdx-correct@^3.0.0:
   version "3.2.0"
@@ -5309,6 +5360,13 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -5969,7 +6027,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.2.1:
+yargs@^17.2.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
Previously the tests of bumping the samples and testing the build was run sequentially, due to the amount of samples we are using the CI for building PRs was getting slower.

The PR implements two changes: 
- Github Actions: a vm for each test, and reuse of the built capacitor package.
- Local: use the concurrency dependency allowing to build and test all samples in parallel.
 I tried using the concurrency and similar methods to only use a single VM on Github Actions but yarn seems too unstable when installing from multiple sources at the same time so I opted for using the simpler version of just using multiple macos virtual machines.

Measured time: before : 8 minutes, after: 1 minute 30 seconds

- Minor change: 
- moved the build job to the top since the below jobs depends on it (just a visual change)

#skip-changelog