### PR TITLE
Feat: Add close function to the main SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add close function on `@sentry/capacitor` ([#664](https://github.com/getsentry/sentry-capacitor/pull/664))
+- Expose `getClient` on `@sentry/capacitor` ([#664](https://github.com/getsentry/sentry-capacitor/pull/664))
+
 ### Fixes
 
 - Accept undefined as value for tags ([#656](https://github.com/getsentry/sentry-capacitor/pull/656))

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -334,6 +334,12 @@ public class SentryCapacitor extends Plugin {
     }
 
     @PluginMethod
+    public void closeNativeSdk(PluginCall call) {
+        Sentry.close();
+        call.resolve();
+    }
+
+    @PluginMethod
     public void setExtra(PluginCall call) {
         if (call.getData().has("key") && call.getData().has("value")) {
             Sentry.configureScope(scope -> {

--- a/example/ionic-angular-v3/src/app/tab2/tab2.page.html
+++ b/example/ionic-angular-v3/src/app/tab2/tab2.page.html
@@ -39,5 +39,12 @@
         >Capture context message</ion-button
       >
     </label>
+
+    <label>
+      Close the SDK
+      <ion-button (click)="close()"
+        >Close the SDK</ion-button
+      >
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular-v3/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v3/src/app/tab2/tab2.page.ts
@@ -38,4 +38,11 @@ export class Tab2Page {
       `${Date.now()}: Captured message with added context.`,
     );
   }
+
+  public close(): void {
+    Sentry.close();
+    Sentry.captureMessage(
+      `${Date.now()}: Captured message with custom tag.`,
+    );
+  }
 }

--- a/example/ionic-angular-v3/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v3/src/app/tab2/tab2.page.ts
@@ -41,8 +41,5 @@ export class Tab2Page {
 
   public close(): void {
     Sentry.close();
-    Sentry.captureMessage(
-      `${Date.now()}: Captured message with custom tag.`,
-    );
   }
 }

--- a/example/ionic-angular-v4/src/app/tab2/tab2.page.html
+++ b/example/ionic-angular-v4/src/app/tab2/tab2.page.html
@@ -39,5 +39,12 @@
         >Capture context message</ion-button
       >
     </label>
+
+    <label>
+      Close the SDK
+      <ion-button (click)="close()"
+        >Close the SDK</ion-button
+      >
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular-v4/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v4/src/app/tab2/tab2.page.ts
@@ -39,9 +39,6 @@ export class Tab2Page {
   }
   public close(): void {
     Sentry.close();
-    Sentry.captureMessage(
-      `${Date.now()}: Captured message with custom tag.`,
-    );
   }
 
 }

--- a/example/ionic-angular-v4/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v4/src/app/tab2/tab2.page.ts
@@ -37,4 +37,11 @@ export class Tab2Page {
       `${Date.now()}: Captured message with added context.`,
     );
   }
+  public close(): void {
+    Sentry.close();
+    Sentry.captureMessage(
+      `${Date.now()}: Captured message with custom tag.`,
+    );
+  }
+
 }

--- a/example/ionic-angular-v5/src/app/tab2/tab2.page.html
+++ b/example/ionic-angular-v5/src/app/tab2/tab2.page.html
@@ -39,5 +39,12 @@
         >Capture context message</ion-button
       >
     </label>
+
+    <label>
+      Close the SDK
+      <ion-button (click)="close()"
+        >Close the SDK</ion-button
+      >
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular-v5/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v5/src/app/tab2/tab2.page.ts
@@ -40,8 +40,5 @@ export class Tab2Page {
 
   public close(): void {
     Sentry.close();
-    Sentry.captureMessage(
-      `${Date.now()}: Captured message with custom tag.`,
-    );
   }
 }

--- a/example/ionic-angular-v5/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v5/src/app/tab2/tab2.page.ts
@@ -37,4 +37,11 @@ export class Tab2Page {
       `${Date.now()}: Captured message with added context.`,
     );
   }
+
+  public close(): void {
+    Sentry.close();
+    Sentry.captureMessage(
+      `${Date.now()}: Captured message with custom tag.`,
+    );
+  }
 }

--- a/example/ionic-angular-v6/android/app/src/main/assets/capacitor.config.json
+++ b/example/ionic-angular-v6/android/app/src/main/assets/capacitor.config.json
@@ -1,7 +1,6 @@
 {
 	"appId": "io.ionic.starter",
 	"appName": "ionic-angular",
-	"bundledWebRuntime": false,
 	"plugins": {
 		"SplashScreen": {
 			"launchShowDuration": 0

--- a/example/ionic-angular-v6/capacitor.config.ts
+++ b/example/ionic-angular-v6/capacitor.config.ts
@@ -3,7 +3,6 @@ import { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'io.ionic.starter',
   appName: 'ionic-angular',
-  bundledWebRuntime: false,
   plugins: {
     SplashScreen: {
       launchShowDuration: 0,

--- a/example/ionic-angular-v6/ios/App/App/capacitor.config.json
+++ b/example/ionic-angular-v6/ios/App/App/capacitor.config.json
@@ -1,7 +1,6 @@
 {
 	"appId": "io.ionic.starter",
 	"appName": "ionic-angular",
-	"bundledWebRuntime": false,
 	"plugins": {
 		"SplashScreen": {
 			"launchShowDuration": 0

--- a/example/ionic-angular-v6/src/app/tab2/tab2.page.html
+++ b/example/ionic-angular-v6/src/app/tab2/tab2.page.html
@@ -39,5 +39,12 @@
         >Capture context message</ion-button
       >
     </label>
+
+    <label>
+      Close the SDK
+      <ion-button (click)="close()"
+        >Close the SDK</ion-button
+      >
+    </label>
   </section>
 </ion-content>

--- a/example/ionic-angular-v6/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v6/src/app/tab2/tab2.page.ts
@@ -40,8 +40,5 @@ export class Tab2Page {
 
   public close(): void {
     Sentry.close();
-    Sentry.captureMessage(
-      `${Date.now()}: Captured message with custom tag.`,
-    );
   }
 }

--- a/example/ionic-angular-v6/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v6/src/app/tab2/tab2.page.ts
@@ -37,4 +37,11 @@ export class Tab2Page {
       `${Date.now()}: Captured message with added context.`,
     );
   }
+
+  public close(): void {
+    Sentry.close();
+    Sentry.captureMessage(
+      `${Date.now()}: Captured message with custom tag.`,
+    );
+  }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -15,5 +15,6 @@ CAP_PLUGIN(SentryCapacitor, "SentryCapacitor",
            CAP_PLUGIN_METHOD(setUser, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(addBreadcrumb, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(clearBreadcrumbs, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(closeNativeSdk, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setContext, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(crash, CAPPluginReturnPromise);)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -281,7 +281,7 @@ public class SentryCapacitor: CAPPlugin {
         call.resolve()
     }
 
-    @objc func closeNativeSdk:(_ call: CAPPluginCall ) {
+    @objc func closeNativeSdk(_ call: CAPPluginCall ) {
         SentrySDK.close()
         call.resolve()
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -281,6 +281,11 @@ public class SentryCapacitor: CAPPlugin {
         call.resolve()
     }
 
+    @objc func closeNativeSdk:(_ call: CAPPluginCall ) {
+        SentrySDK.close()
+        call.resolve()
+    }
+
     @objc func crash(_ call: CAPPluginCall) {
         SentrySDK.crash()
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/getsentry/sentry-capacitor"
   },
-  "version": "0.18.0",
+  "version": "0.18.3",
   "description": "Official Sentry SDK for Capacitor",
   "types": "dist/esm/index.d.ts",
   "main": "dist/build/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/getsentry/sentry-capacitor"
   },
-  "version": "0.18.3",
+  "version": "0.18.0",
   "description": "Official Sentry SDK for Capacitor",
   "types": "dist/esm/index.d.ts",
   "main": "dist/build/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -17,6 +17,7 @@ export interface ISentryCapacitorPlugin {
   ): PromiseLike<boolean>;
 
   clearBreadcrumbs(): void;
+  closeNativeSdk(): Promise<void>;
   crash(): void;
   fetchNativeRelease(): Promise<{
     build: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   getCurrentHub,
   Hub,
   Scope,
+  getClient,
   setContext,
   setExtra,
   setExtras,
@@ -45,4 +46,4 @@ export { Replay, BrowserTracing } from '@sentry/browser'
 
 export { SDK_NAME, SDK_VERSION } from './version';
 export type { CapacitorOptions } from './options';
-export { init, nativeCrash } from './sdk';
+export { init, nativeCrash, close } from './sdk';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,7 +3,8 @@ import {
   defaultIntegrations,
   init as browserInit
 } from '@sentry/browser';
-import { Hub, makeMain } from '@sentry/core';
+import { getClient, Hub, makeMain } from '@sentry/core';
+import { logger } from '@sentry/utils';
 
 import { DeviceContext, EventOrigin, Release, SdkInfo } from './integrations';
 import { createCapacitorRewriteFrames } from './integrations/rewriteframes';
@@ -82,6 +83,23 @@ export function init<T>(
   void NATIVE.initNativeSdk(mobileOptions);
   originalInit(browserOptions);
 }
+
+/**
+ * Closes the SDK, stops sending events.
+ */
+export async function close(): Promise<void> {
+  try {
+    const client = getClient();
+
+    if (client) {
+      await client.close();
+      await NATIVE.closeNativeSdk();
+    }
+  } catch (e) {
+    logger.error('Failed to close the SDK');
+  }
+}
+
 
 /**
  * If native client is available it will trigger a native crash

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -279,14 +279,19 @@ export const NATIVE = {
   /**
    * Closes the Native Layer SDK
    */
-  closeNativeSdk(): Promise<void> {
-    if (!this.enableNative || !this.isNativeClientAvailable()) {
+   closeNativeSdk(): Promise<void> {
+    if (!this.enableNative) {
+      // Only log and avoid rejecting.
+      logger.debug(this._DisabledNativeError);
       return Promise.resolve();
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
 
-    return SentryCapacitor.closeNativeSdk().then(() => {
-      this.enableNative = false;
-    });
+     return SentryCapacitor.closeNativeSdk().then(() => {
+       this.enableNative = false;
+     });
   },
 
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -275,6 +275,21 @@ export const NATIVE = {
     SentryCapacitor.clearBreadcrumbs();
   },
 
+
+  /**
+   * Closes the Native Layer SDK
+   */
+  closeNativeSdk(): Promise<void> {
+    if (!this.enableNative || !this.isNativeClientAvailable()) {
+      return Promise.resolve();
+    }
+
+    return SentryCapacitor.closeNativeSdk().then(() => {
+      this.enableNative = false;
+    });
+  },
+
+
   /**
    * Sets context on the native scope. Not implemented in Android yet.
    * @param key string

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -279,7 +279,7 @@ export const NATIVE = {
   /**
    * Closes the Native Layer SDK
    */
-   closeNativeSdk(): Promise<void> {
+  closeNativeSdk(): Promise<void> {
     if (!this.enableNative) {
       // Only log and avoid rejecting.
       logger.debug(this._DisabledNativeError);
@@ -289,9 +289,9 @@ export const NATIVE = {
       throw this._NativeClientError;
     }
 
-     return SentryCapacitor.closeNativeSdk().then(() => {
-       this.enableNative = false;
-     });
+    return SentryCapacitor.closeNativeSdk().then(() => {
+      this.enableNative = false;
+    });
   },
 
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -61,6 +61,7 @@ jest.mock('../src/plugin', () => {
       setUser: jest.fn(() => {
         return;
       }),
+      closeNativeSdk: jest.fn(() => Promise.resolve()),
     },
   };
 });
@@ -625,4 +626,14 @@ describe('Tests Native Wrapper', () => {
       expect(SentryCapacitor.fetchNativeDeviceContexts).not.toBeCalled();
     });
   });
+
+  describe('closeNativeSdk', () => {
+    test('closeNativeSdk calls native bridge', async () => {
+      await NATIVE.closeNativeSdk();
+
+      expect(SentryCapacitor.closeNativeSdk).toBeCalled();
+      expect(NATIVE.enableNative).toBe(false);
+    });
+  });
+
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -636,4 +636,12 @@ describe('Tests Native Wrapper', () => {
     });
   });
 
+  test('closeNativeSdk called twice does not throw error.', async () => {
+    logger.debug = jest.fn();
+    await NATIVE.closeNativeSdk();
+    expect(logger.debug).not.toBeCalled();
+
+    await NATIVE.closeNativeSdk();
+    expect(logger.debug).toBeCalledWith(NATIVE._DisabledNativeError);
+  });
 });


### PR DESCRIPTION
This PR exposes the close function that closes the client and the native layer.

Minor changes:

# Sample
* Removed deprecated flags from the latest samples.
* Added a button to call the close function.
Closes #663