### PR TITLE
Expose missing exports from sentry core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * spanIsSampled,
 * setMeasurement,
 * getGlobalScope,
-* getIsolationScope,
 * getClient,
 * setCurrentClient,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Features
+
+- Add the following functions on `@sentry/capacitor` ([#666](https://github.com/getsentry/sentry-capacitor/pull/666))
+
+* flush,
+* getActiveSpan,
+* spanToJSON,
+* spanIsSampled,
+* setMeasurement,
+* getGlobalScope,
+* getIsolationScope,
+* getClient,
+* setCurrentClient,
+
 ### Fixes
 
 - Accept undefined as value for tags ([#656](https://github.com/getsentry/sentry-capacitor/pull/656))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,9 @@
 
 ### Features
 
-- Add the following functions on `@sentry/capacitor` ([#666](https://github.com/getsentry/sentry-capacitor/pull/666))
+- Add the following functions to `@sentry/capacitor` ([#666](https://github.com/getsentry/sentry-capacitor/pull/666))
+  - `flush`, `getActiveSpan`, `spanToJSON`, `spanIsSampled`, `setMeasurement`, `getGlobalScope` and `setCurrentClient`.
 
-* flush.
-* getActiveSpan.
-* spanToJSON.
-* spanIsSampled.
-* setMeasurement.
-* getGlobalScope.
-* getClient.
-* setCurrentClient.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 - Add the following functions on `@sentry/capacitor` ([#666](https://github.com/getsentry/sentry-capacitor/pull/666))
 
-* flush,
-* getActiveSpan,
-* spanToJSON,
-* spanIsSampled,
-* setMeasurement,
-* getGlobalScope,
-* getClient,
-* setCurrentClient,
+* flush.
+* getActiveSpan.
+* spanToJSON.
+* spanIsSampled.
+* setMeasurement.
+* getGlobalScope.
+* getClient.
+* setCurrentClient.
 
 ### Fixes
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,13 +33,26 @@ export {
   setExtras,
   setTag,
   setTags,
+  flush,
   setUser,
   // eslint-disable-next-line deprecation/deprecation
   startTransaction,
+  withScope,
+
+  // V8
+  startInactiveSpan,
   startSpan,
   startSpanManual,
-  startInactiveSpan,
-  withScope,
+  getActiveSpan,
+  spanToJSON,
+  spanIsSampled,
+  setMeasurement,
+  getGlobalScope,
+  getIsolationScope,
+  getClient,
+  setCurrentClient,
+  metrics,
+
 } from '@sentry/core';
 export { Replay, BrowserTracing } from '@sentry/browser'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export {
   setMeasurement,
   getGlobalScope,
   // getIsolationScope, TODO: Verify why it's not working
-  getClient,
   setCurrentClient,
 
 } from '@sentry/core';

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,10 +48,9 @@ export {
   spanIsSampled,
   setMeasurement,
   getGlobalScope,
-  getIsolationScope,
+  // getIsolationScope, TODO: Verify why it's not working
   getClient,
   setCurrentClient,
-  metrics,
 
 } from '@sentry/core';
 export { Replay, BrowserTracing } from '@sentry/browser'


### PR DESCRIPTION
The following exports are now exposed from Sentry core:

-   flush,
-   getActiveSpan,
-   spanToJSON,
-   spanIsSampled,
-   setMeasurement,
-   getGlobalScope,
-   getIsolationScope,
-   getClient,
-   setCurrentClient,
-   metrics,

They were tested locally and there will be a follow up PR for using those exports on the sample app (https://github.com/getsentry/sentry-capacitor/issues/665)