### PR TITLE
Remove hub and tracing from  update-javascript.sh

### DIFF
--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -4,8 +4,5 @@ set -euo pipefail
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
 packages=('@sentry/browser' '@sentry/core' '@sentry/integrations' '@sentry/types' '@sentry/utils')
-#TODO: remove @sentry/hub and @sentry/tracing on next major release.
-#https://github.com/getsentry/sentry-capacitor/issues/511
-packages+=('@sentry/hub' '@sentry/tracing')
 packages+=('@sentry-internal/eslint-config-sdk' '@sentry-internal/eslint-plugin-sdk' '@sentry-internal/typescript')
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
They no longer exist on v8 so I am removing them from the script check.

Close #511 

#skip-changelog.