### PR TITLE
fix: wrong pod lock files version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - Capacitor (5.5.1):
     - CapacitorCordova
   - CapacitorCordova (5.5.1)
-  - Sentry/HybridSDK (8.21.0):
-    - SentryPrivate (= 8.21.0)
-  - SentryPrivate (8.21.0)
+  - Sentry/HybridSDK (8.36.0):
+    - SentryPrivate (= 8.36.0)
+  - SentryPrivate (8.36.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Sentry/HybridSDK (= 8.21.0)
+  - Sentry/HybridSDK (= 8.36.0)
 
 SPEC REPOS:
   trunk:
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
   CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
-  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
 
 PODFILE CHECKSUM: 6d05c518e9f9e84fa14f2f52d1a6d0939d24afca


### PR DESCRIPTION
Fix pod lock with the wrong version, should only impact CI builds.

#skip-changelog.
