### PR TITLE
Fix: normalize should use Options limits or default

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -22,9 +22,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         # we use a hash of yarn.lock as our cache key, because if it hasn't changed, our dependencies haven't changed,
         # so no need to reinstall them
       - name: Compute dependency cache key
@@ -50,9 +50,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - name: Check dependency cache
         uses: actions/cache@v4.1.0
         with:
@@ -107,9 +107,9 @@ jobs:
           - bump: 'sample-vue'
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - name: Check dependency cache
         uses: actions/cache@v4.1.0
         with:
@@ -149,9 +149,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - name: Check dependency cache
         uses: actions/cache@v4.1.0
         with:
@@ -171,9 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - name: Check dependency cache
         uses: actions/cache@v4.1.0
         with:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -69,11 +69,11 @@ jobs:
         # packages, and so `yarn build` should always run. This `if` check is therefore only there for testing CI issues
         # where the built packages are beside the point. In that case, you can change `BUILD_CACHE_KEY` (at the top of
         # this file) to a constant and skip rebuilding all of the packages each time CI runs.
-        if: steps.cache_built_packages.outputs.cache-hit == '!= true'
+        if: steps.cache_built_packages.outputs.cache-hit != 'true'
         run: yarn build
         # yarn.lock cannot be dirty when releasing a new version.
       - name: Check if yarn.lock is dirty
-        if: steps.cache_built_packages.outputs.cache-hit == '!= true'
+        if: steps.cache_built_packages.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Publish package locally
         run: |

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -69,11 +69,11 @@ jobs:
         # packages, and so `yarn build` should always run. This `if` check is therefore only there for testing CI issues
         # where the built packages are beside the point. In that case, you can change `BUILD_CACHE_KEY` (at the top of
         # this file) to a constant and skip rebuilding all of the packages each time CI runs.
-        if: steps.cache_built_packages.outputs.cache-hit == ''
+        if: steps.cache_built_packages.outputs.cache-hit == '!= true'
         run: yarn build
         # yarn.lock cannot be dirty when releasing a new version.
       - name: Check if yarn.lock is dirty
-        if: steps.cache_built_packages.outputs.cache-hit == ''
+        if: steps.cache_built_packages.outputs.cache-hit == '!= true'
         run: yarn install --frozen-lockfile
       - name: Publish package locally
         run: |

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 
       - name: Install dependencies
-        if: steps.cache_dependencies.outputs.cache-hit == ''
+        if: steps.cache_dependencies.outputs.cache-hit != 'true'
         run: yarn install
     outputs:
       dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > [migration guide](https://docs.sentry.io/platforms/javascript/guides/capacitor/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- options normalizeDepth and normalizeMaxBreadth are now being respected when adding a breadcrumb. ([#766](https://github.com/getsentry/sentry-capacitor/pull/766))
+
 ## 1.0.1
 
 ### Dependencies

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,3 +1,4 @@
+import { getClient } from '@sentry/core';
 import { normalize } from '@sentry/utils';
 
 const KEY = 'value';
@@ -7,7 +8,8 @@ const KEY = 'value';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function convertToNormalizedObject(data: unknown): Record<string, any> {
-  const normalized: unknown = normalize(data);
+  const options = getClient()?.getOptions();
+  const normalized: unknown = normalize(data, options?.normalizeDepth, options?.normalizeMaxBreadth);
   if (normalized === null || typeof normalized !== 'object') {
     return {
       [KEY]: normalized,

--- a/test/utils/normalize.test.ts
+++ b/test/utils/normalize.test.ts
@@ -1,7 +1,21 @@
+import { getClient } from '@sentry/core';
+
+jest.mock('@sentry/core', () => ({
+  getClient: jest.fn(),
+}));
 import { convertToNormalizedObject } from '../../src/utils/normalize';
 
 describe('normalize', () => {
   describe('convertToNormalizedObject', () => {
+    beforeEach(() => {
+      (getClient as jest.Mock).mockReturnValue({
+          getOptions: jest.fn().mockReturnValue({
+              normalizeDepth: undefined,
+              normalizeMaxBreadth: undefined,
+          }),
+      });
+    });
+
     test('output equals input for normalized objects', () => {
       const actualResult = convertToNormalizedObject({ foo: 'bar' });
       expect(actualResult).toEqual({ foo: 'bar' });
@@ -20,6 +34,43 @@ describe('normalize', () => {
     test('converts null to an object', () => {
       const actualResult = convertToNormalizedObject(null);
       expect(actualResult).toEqual({ value: null });
+    });
+
+    test('respect normalizeDepth and normalizeMaxBreadth when set', () => {
+      (getClient as jest.Mock).mockReturnValue({
+        getOptions: jest.fn().mockReturnValue({
+          normalizeDepth: 2,
+          normalizeMaxBreadth: 3,
+        })
+      });
+      const obj = {
+        key1: '1',
+        keyparent: {
+          child1: '1',
+          childparent2: {
+            child1: '1'
+          },
+          child2: '2',
+          child3: '3'
+        },
+        key2: '2',
+        key3: '3',
+      };
+      const expectedObj = {
+        key1: '1',
+        keyparent: {
+          child1: '1',
+          childparent2: '[Object]',
+          child2: '2',
+          child3: '[MaxProperties ~]'
+        },
+        key2: '2',
+        key3: '[MaxProperties ~]',
+      }
+
+      const actualResult = convertToNormalizedObject(obj);
+      expect((actualResult)).toStrictEqual(expectedObj);
+
     });
   });
 });

--- a/test/utils/normalize.test.ts
+++ b/test/utils/normalize.test.ts
@@ -70,7 +70,6 @@ describe('normalize', () => {
 
       const actualResult = convertToNormalizedObject(obj);
       expect((actualResult)).toStrictEqual(expectedObj);
-
     });
   });
 });


### PR DESCRIPTION
This change allows Breadcrumbs to respect the defined limits of `normalizeDepth` and `normalizeMaxBreadth`.
Before that, it would use the limits of 100 for `normalizeDepth` and infinite for `normalizeMaxBreadth`

The PR also updates GitHub Checks that were using old versions, which were blocking the build to pass.
