### PR TITLE
scripts/check-siblings: Update to work with yarn patch.

### DIFF
--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -68,7 +68,7 @@ function ValidateSentryPackageParameters(packages) {
       if (installedVersion.split('@').length === 2) {
         errorMessages.push("You must specify the version to the package " + installedVersion + ". ( " + installedVersion + "@" + siblingVersion + ")");
       }
-      else if (!installedVersion.endsWith(siblingVersion)) {
+      else if (!installedVersion.endsWith(siblingVersion) && !installedVersion.includes('%3A' + siblingVersion + '#')) {
         errorMessages.push("You tried to install " + installedVersion + ", but the current version of  @sentry/capacitor is only compatible with version " + siblingVersion + ". Please install the dependency with the correct version.");
       }
     }
@@ -137,7 +137,7 @@ function CheckSiblings() {
 
   for (const lineData of packageJson) {
     let sentryRef = lineData.match(jsonFilter);
-    if (sentryRef && sentryRef[2] !== siblingVersion) {
+    if (sentryRef && sentryRef[2] !== siblingVersion && !sentryRef[2].includes('%3A' + siblingVersion + '#')) {
       incompatiblePackages.push(['@sentry/' + sentryRef[1], sentryRef[2]]);
     }
   }


### PR DESCRIPTION
I'm using `@sentry/nextjs` version `8.27.0`, and I cannot update to the latest version because of a [bug](https://github.com/getsentry/sentry-javascript/issues/14077) introduced in the next version. And there was another [bug](https://github.com/getsentry/sentry-javascript/issues/13270) on `8.27.0`. So I had to use `yarn patch` to fix the latter mentioned bug without updating the package.

`yarn patch` changes the version to something like this: `patch:@sentry/nextjs@npm%3A8.27.0#~/.yarn/patches/@sentry-nextjs-npm-8.27.0-0e3a1ce4c2.patch` This means that exact version `8.27.0` was used as base and patched.

This PR updates the sibling version check to work with `yarn patch` versions.

#skip-changelog