### PR TITLE
 fix(core): Export missing span utils from Sentry Core 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixes
 
 - options normalizeDepth and normalizeMaxBreadth are now being respected when adding a breadcrumb. ([#766](https://github.com/getsentry/sentry-capacitor/pull/766))
-- Add missing `withActiveSpan` and `suppressTracing` exports from `@sentry/core` ([#XX](https://github.com/getsentry/sentry-capacitor/pull/XX))
+- Add missing `withActiveSpan` and `suppressTracing` exports from `@sentry/core` ([#776](https://github.com/getsentry/sentry-capacitor/pull/776))
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - options normalizeDepth and normalizeMaxBreadth are now being respected when adding a breadcrumb. ([#766](https://github.com/getsentry/sentry-capacitor/pull/766))
+- Add missing `withActiveSpan` and `suppressTracing` exports from `@sentry/core` ([#XX](https://github.com/getsentry/sentry-capacitor/pull/XX))
 
 ## 1.0.1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ export {
   setContext,
   setExtra,
   setExtras,
+  withActiveSpan,
+  suppressTracing,
   setTag,
   setTags,
   flush,


### PR DESCRIPTION
This PR adds missing span utils export from @sentry/core.
