### PR TITLE
Ref: use --sig parameter when bumping samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bump:v4": "cd example/ionic-angular-v4 && yalc link @sentry/capacitor && yalc add broken_module && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:v3": "cd example/ionic-angular-v3 && yalc link @sentry/capacitor && yarn install --check-files && yarn run build && yarn bump:sample-pod && npx cap sync",
     "bump:sample-vue": "cd example/ionic-vue3 && yalc link @sentry/capacitor && yarn install --check-files && ionic build && yarn run bump:sample-pod && npx cap sync",
-    "bump:samples": "yalc publish && yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
+    "bump:samples": "yalc publish --sig && yarn concurrently --kill-others-on-fail \"yarn run bump:v6\" \"yarn run bump:v5\" \"yarn run bump:v4\" \"yarn run bump:v3\" \"yarn run bump:sample-vue\""
   },
   "keywords": [
     "capacitor",


### PR DESCRIPTION
Ionic usually gets the wrong of the SDK, despite the right one being installed, adding the --sig parameter to publish will add the hash of the SDK and will avoid conflicts with wrong versions being tested with the sample.

More information: https://github.com/wclr/yalc?tab=readme-ov-file#publish

#skip-changelog