### PR TITLE
internal: Enable corepack

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v4
+      - run: corepack enable
       - name: Set up Node
         uses: actions/setup-node@v4
         # we use a hash of yarn.lock as our cache key, because if it hasn't changed, our dependencies haven't changed,
@@ -51,6 +52,7 @@ jobs:
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v4
+      - run: corepack enable
       - name: Set up Node
         uses: actions/setup-node@v4
       - name: Check dependency cache
@@ -108,6 +110,7 @@ jobs:
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v4
+      - run: corepack enable
       - name: Set up Node
         uses: actions/setup-node@v4
       - name: Check dependency cache
@@ -150,6 +153,7 @@ jobs:
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v4
+      - run: corepack enable
       - name: Set up Node
         uses: actions/setup-node@v4
       - name: Check dependency cache
@@ -172,6 +176,7 @@ jobs:
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v4
+      - run: corepack enable
       - name: Set up Node
         uses: actions/setup-node@v4
       - name: Check dependency cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
+      - run: corepack enable
       - name: Install Dependencies
         run: yarn install
       - name: Prepare release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 You need:
 
-- [nodejs](https://nodejs.org/en/download/) 8 or higher
+- [nodejs](https://nodejs.org/en/download/) 18 or higher (with corepack enabled)
 - [yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or higher
 - [yalc](https://github.com/wclr/yalc) (can be installed with `yarn global add yalc`)
 - http-server

--- a/package.json
+++ b/package.json
@@ -132,5 +132,6 @@
     "testMatch": [
       "**/*.test.(ts|tsx)"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Since other SDKs are using corepack and the change was simple here, I thought on enabling it here so it avoids corepack trying to install the incorrect version of yarn every time I work on Capacitor with corepack enabled.

#skip-changelog.