### PR TITLE
Bugfix: tracePropationTargets option ignored in CapacitorHTTP methods

### DIFF
--- a/src/nativeOptions.ts
+++ b/src/nativeOptions.ts
@@ -39,6 +39,7 @@ export function FilterNativeOptions(
     tracesSampleRate: options.tracesSampleRate,
     // tunnel: options.tunnel: Only handled on the JavaScript Layer.
     enableCaptureFailedRequests: options.enableCaptureFailedRequests,
+    tracePropagationTargets: options.tracePropagationTargets,
     ...iOSParameters(options),
   };
 }


### PR DESCRIPTION
This update addresses an issue where the tracePropagationTargets option was being ignored in various CapacitorHTTP methods.