### PR TITLE
Revert "Bugfix: tracePropationTargets option ignored in CapacitorHTTP methods"

### DIFF
--- a/src/nativeOptions.ts
+++ b/src/nativeOptions.ts
@@ -39,7 +39,6 @@ export function FilterNativeOptions(
     tracesSampleRate: options.tracesSampleRate,
     // tunnel: options.tunnel: Only handled on the JavaScript Layer.
     enableCaptureFailedRequests: options.enableCaptureFailedRequests,
-    tracePropagationTargets: options.tracePropagationTargets,
     ...iOSParameters(options),
   };
 }


### PR DESCRIPTION
Reverts getsentry/sentry-capacitor#803

We will keep track of the feature here: https://github.com/getsentry/sentry-capacitor/issues/820

#skip-changelog.