### PR TITLE
ref: remove sentry utils update

### DIFF
--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
-packages=('@sentry/browser' '@sentry/core' '@sentry/types' '@sentry/utils')
+packages=('@sentry/browser' '@sentry/core' '@sentry/types')
 packages+=('@sentry-internal/eslint-config-sdk' '@sentry-internal/eslint-plugin-sdk' '@sentry-internal/typescript')
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
Sentry JavaScript V9 no longer uses sentry/utils and it is now deprecated, this PR removes this package from the update list.

#skip-changelog