### PR TITLE
chore: update Sentry version to 8.48.0 in Podfile.lock files

### DIFF
--- a/example/ionic-angular-v5/ios/App/Podfile.lock
+++ b/example/ionic-angular-v5/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (5.5.1):
     - CapacitorCordova
   - CapacitorCordova (5.5.1)
-  - Sentry/HybridSDK (8.36.0)
-  - "SentryCapacitor (1.1.0+353d390b)":
+  - Sentry/HybridSDK (8.48.0)
+  - SentryCapacitor (1.2.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.36.0)
+    - Sentry/HybridSDK (= 8.48.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
   CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
-  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  SentryCapacitor: cc4fb59913373742c2cefa08a7b03d0158a09f9c
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
+  SentryCapacitor: 3d2d6bb73b0b38deba544236d1e7ef87803a0ae5
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 

--- a/example/ionic-angular-v6/ios/App/Podfile.lock
+++ b/example/ionic-angular-v6/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (6.0.0):
     - CapacitorCordova
   - CapacitorCordova (6.0.0)
-  - Sentry/HybridSDK (8.36.0)
-  - "SentryCapacitor (1.1.0+353d390b)":
+  - Sentry/HybridSDK (8.48.0)
+  - SentryCapacitor (1.2.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.36.0)
+    - Sentry/HybridSDK (= 8.48.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 559d073c4ca6c27f8e7002c807eea94c3ba435a9
   CapacitorCordova: 8c4bfdf69368512e85b1d8b724dd7546abeb30af
-  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  SentryCapacitor: cc4fb59913373742c2cefa08a7b03d0158a09f9c
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
+  SentryCapacitor: 3d2d6bb73b0b38deba544236d1e7ef87803a0ae5
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 

--- a/example/ionic-angular-v7/ios/App/Podfile.lock
+++ b/example/ionic-angular-v7/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorCordova (7.0.1)
-  - Sentry/HybridSDK (8.36.0)
-  - "SentryCapacitor (1.1.0+353d390b)":
+  - Sentry/HybridSDK (8.48.0)
+  - SentryCapacitor (1.2.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.36.0)
+    - Sentry/HybridSDK (= 8.48.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  SentryCapacitor: 9d2514b23ffc03705cf6052d5baaab705026cb86
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
+  SentryCapacitor: 27370599e6b015be5693461df031f8ff6505151e
 
 PODFILE CHECKSUM: e512db45f101b9092c98513e2bceba3944192dde
 

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -10,10 +10,10 @@ PODS:
     - Capacitor
   - CapacitorStatusBar (5.0.6):
     - Capacitor
-  - Sentry/HybridSDK (8.36.0)
-  - SentryCapacitor (1.0.0-beta.1):
+  - Sentry/HybridSDK (8.48.0)
+  - SentryCapacitor (1.2.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.36.0)
+    - Sentry/HybridSDK (= 8.48.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -51,8 +51,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 1fffc1217c7e64a472d7845be50fb0c2f7d4204c
   CapacitorKeyboard: ce5e01064cf57a2c05b32565310713b7fe6cc6f9
   CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
-  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  SentryCapacitor: ab15688e690007c3793b646f50b028a02fa909ee
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
+  SentryCapacitor: 3d2d6bb73b0b38deba544236d1e7ef87803a0ae5
 
 PODFILE CHECKSUM: a972544de6bcfa1a17161b0b4ef85e6ee7586f79
 


### PR DESCRIPTION
#skip-changelog 

Fixes https://github.com/getsentry/sentry-capacitor/pull/751, which have not updated the lock file automatically