### PR TITLE
Ref: podfile update

### DIFF
--- a/example/ionic-angular-v6/ios/App/Podfile.lock
+++ b/example/ionic-angular-v6/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (6.0.0):
     - CapacitorCordova
   - CapacitorCordova (6.0.0)
-  - Sentry/HybridSDK (8.48.0)
-  - SentryCapacitor (1.2.1):
+  - Sentry/HybridSDK (8.50.1)
+  - SentryCapacitor (2.0.0-beta.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.48.0)
+    - Sentry/HybridSDK (= 8.50.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 559d073c4ca6c27f8e7002c807eea94c3ba435a9
   CapacitorCordova: 8c4bfdf69368512e85b1d8b724dd7546abeb30af
-  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
-  SentryCapacitor: 3d2d6bb73b0b38deba544236d1e7ef87803a0ae5
+  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
+  SentryCapacitor: 05538a4a60e82e71861e08c144444ace7f91039c
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 

--- a/example/ionic-angular-v7/ios/App/Podfile.lock
+++ b/example/ionic-angular-v7/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorCordova (7.0.1)
-  - Sentry/HybridSDK (8.48.0)
-  - SentryCapacitor (1.2.1):
+  - Sentry/HybridSDK (8.50.1)
+  - SentryCapacitor (2.0.0-beta.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.48.0)
+    - Sentry/HybridSDK (= 8.50.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
-  SentryCapacitor: 27370599e6b015be5693461df031f8ff6505151e
+  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
+  SentryCapacitor: 1fed5bc6d2ac2edeab0131c28ed8b2d017fc1eda
 
 PODFILE CHECKSUM: e512db45f101b9092c98513e2bceba3944192dde
 

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -10,10 +10,10 @@ PODS:
     - Capacitor
   - CapacitorStatusBar (5.0.6):
     - Capacitor
-  - Sentry/HybridSDK (8.48.0)
-  - SentryCapacitor (1.2.1):
+  - Sentry/HybridSDK (8.50.1)
+  - SentryCapacitor (2.0.0-beta.1):
     - Capacitor
-    - Sentry/HybridSDK (= 8.48.0)
+    - Sentry/HybridSDK (= 8.50.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -51,8 +51,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 1fffc1217c7e64a472d7845be50fb0c2f7d4204c
   CapacitorKeyboard: ce5e01064cf57a2c05b32565310713b7fe6cc6f9
   CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
-  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
-  SentryCapacitor: 3d2d6bb73b0b38deba544236d1e7ef87803a0ae5
+  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
+  SentryCapacitor: 05538a4a60e82e71861e08c144444ace7f91039c
 
 PODFILE CHECKSUM: a972544de6bcfa1a17161b0b4ef85e6ee7586f79
 

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -285,14 +285,12 @@
 				"${BUILT_PRODUCTS_DIR}/Capacitor/Capacitor.framework",
 				"${BUILT_PRODUCTS_DIR}/CapacitorCordova/Cordova.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
-				"${BUILT_PRODUCTS_DIR}/SentryPrivate/SentryPrivate.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Capacitor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cordova.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SentryPrivate.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,6 +1,6 @@
 require_relative '../node_modules/@capacitor/ios/scripts/pods_helpers'
 
-platform :ios, '11.0'
+platform :ios, '14.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
@@ -12,7 +12,7 @@ end
 target 'Plugin' do
   capacitor_pods
 
-  pod 'Sentry/HybridSDK', '8.21.0'
+  pod 'Sentry/HybridSDK', '8.50.1'
 end
 
 target 'PluginTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,20 +1,17 @@
 PODS:
-  - Capacitor (5.5.1):
+  - Capacitor (7.0.1):
     - CapacitorCordova
-  - CapacitorCordova (5.5.1)
-  - Sentry/HybridSDK (8.36.0):
-    - SentryPrivate (= 8.36.0)
-  - SentryPrivate (8.36.0)
+  - CapacitorCordova (7.0.1)
+  - Sentry/HybridSDK (8.50.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Sentry/HybridSDK (= 8.36.0)
+  - Sentry/HybridSDK (= 8.50.1)
 
 SPEC REPOS:
   trunk:
     - Sentry
-    - SentryPrivate
 
 EXTERNAL SOURCES:
   Capacitor:
@@ -23,11 +20,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
-  CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
-  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
+  Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
+  CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
+  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
 
-PODFILE CHECKSUM: 6d05c518e9f9e84fa14f2f52d1a6d0939d24afca
+PODFILE CHECKSUM: e4a02eb188d200ec01ac2a041fa1e408619168c3
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2


### PR DESCRIPTION
The main podfile was updated by the bot but it forgot to update the samples and also the lockfiles.

This PR updates the podfiles, along to pointing to a newer capacitor podfile that is not deprecated.

#skip-changelog.