### PR TITLE
Ref: Clear old capacitor version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Break Change
+
+- Drop support for Capacitor 3, 4 and 5.
+
 ### Dependencies
 
 - Bump JavaScript SDKs from v9.0.0 to v9.11.0 ([#872](https://github.com/getsentry/sentry-capacitor/pull/872))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Break Change
 
-- Drop support for Capacitor 3, 4 and 5.
+- Drop support for Capacitor 3, 4 and 5. ([#907](https://github.com/getsentry/sentry-capacitor/pull/907))
 
 ### Dependencies
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,15 +16,6 @@ def GetCapacitorVersion() {
   if (compileVersion == 34) {
     return 6
   }
-  else if (compileVersion == 33) {
-    return 5
-  }
-  else if (compileVersion == 32 || compileVersion == 31) {
-    return 4
-  }
-  else if (compileVersion == 30 || compileVersion == 29) {
-    return 3
-  }
   else {
     throw new GradleException("The version of Capacitor is not supported by Sentry, CODE: " + compileVersion)
   }
@@ -42,21 +33,13 @@ if (capVersion >= 7) {
     androidxEspressoCoreVersion = safeExtGet('androidxEspressoCoreVersion', '3.6.1')
   }
 }
-else if (capVersion >= 5) {
-  println "Sentry Capacitor: Applying defaults for Capacitor 5 and 6"
+else {
+  println "Sentry Capacitor: Applying defaults for Capacitor 6"
   targetJavaVersion = JavaVersion.VERSION_17
   defaultMinAndroidVersion = 22
   ext {
     androidxAppCompatVersion = safeExtGet('androidxAppCompatVersion', '1.6.1')
     androidxEspressoCoreVersion = safeExtGet('androidxEspressoCoreVersion', '3.5.1')
-  }
-}
-else {
-  println "Sentry Capacitor: Applying defaults for Capacitor 4."
-  targetJavaVersion = JavaVersion.VERSION_11
-  defaultMinAndroidVersion = 22
-  ext {
-    androidxEspressoCoreVersion = safeExtGet('androidxEspressoCoreVersion', '3.2.0')
   }
 }
 
@@ -66,7 +49,7 @@ android {
   namespace "io.sentry.capacitor"
   compileSdkVersion safeExtGet('compileSdkVersion', defaultSdkVersion)
   defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', defaultMinAndroidVersion) // Same for Capacitor 6 or lower
+    minSdkVersion safeExtGet('minSdkVersion', defaultMinAndroidVersion)
     targetSdkVersion safeExtGet('targetSdkVersion', defaultSdkVersion)
     versionCode 1
     versionName "1.0"

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "@sentry/types": "9.11.0"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.1 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-    "@capacitor/core": "^3.0.1 || ^4.0.0 || ^5.0.0 || ^6.0.0  || ^7.0.0",
-    "@capacitor/ios": "^3.0.1 || ^4.0.0 || ^5.0.0 || ^6.0.0  || ^7.0.0",
+    "@capacitor/android": "^6.0.0 || ^7.0.0",
+    "@capacitor/core": "^6.0.0  || ^7.0.0",
+    "@capacitor/ios": "^6.0.0  || ^7.0.0",
     "@ionic/prettier-config": "^1.0.0",
     "@sentry-internal/eslint-config-sdk": "9.11.0",
     "@sentry-internal/eslint-plugin-sdk": "9.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,22 +514,22 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@capacitor/android@^3.0.1 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-7.0.1.tgz#16c45a305edeb8bcf0b083ea52abcc62ca4e5e70"
-  integrity sha512-jukJJHfkcyEBOkFBJRD3EwXMIIQo7lSv0ExPWgsIliPdGXLAj6ElvK2JaYEzec3vKyLc4RTNFVv0PMEU0vnImg==
+"@capacitor/android@^6.0.0 || ^7.0.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-7.2.0.tgz#f30e313315ab92c500bd57d9f0c4716a46b42f40"
+  integrity sha512-zdhEy3jZPG5Toe/pGzKtDgIiBGywjaoEuQWnGVjBYPlSAEUtAhpZ2At7V0SCb26yluAuzrAUV0Ue+LQeEtHwFQ==
 
-"@capacitor/core@^3.0.1 || ^4.0.0 || ^5.0.0 || ^6.0.0  || ^7.0.0":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@capacitor/core/-/core-7.0.1.tgz#e2a635ffced0aa0e1160f48cffa8d8148f947972"
-  integrity sha512-1Ob9bvA/p8g8aNwK6VesxEekGXowLVf6APjkW4LRnr05H+7z/bke+Q5pn9zqh/GgTbIxAQ/rwZrAZvvxkdm1UA==
+"@capacitor/core@^6.0.0  || ^7.0.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/core/-/core-7.2.0.tgz#fdd1c5d2fbfa257887ce6065f66151a51f0e6d1b"
+  integrity sha512-2zCnA6RJeZ9ec4470o8QMZEQTWpekw9FNoqm5TLc10jeCrhvHVI8MPgxdZVc3mOdFlyieYu4AS1fNxSqbS57Pw==
   dependencies:
     tslib "^2.1.0"
 
-"@capacitor/ios@^3.0.1 || ^4.0.0 || ^5.0.0 || ^6.0.0  || ^7.0.0":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-7.0.1.tgz#f175f74543edc5faa13de927ababfffff450776f"
-  integrity sha512-RN6S1C1k7ue57DFmJM4EizzsYBrahTTiMhcnlHspFLaojgHbFWZbYq1VriuRKysPU1ka/P+klsdtRFsB5K9jyw==
+"@capacitor/ios@^6.0.0  || ^7.0.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-7.2.0.tgz#c3d9435582e5267b57085229e5678d1d53b15b5a"
+  integrity sha512-MQgRZcXZpbpjN83bjkGrzQd7s3XeHBZplmWf38/msF/siMGJKLrXNmNzmmPIWA5Xpi/aH6UoJFk1wXuU2U+zMg==
 
 "@chevrotain/cst-dts-gen@11.0.3":
   version "11.0.3"


### PR DESCRIPTION
To keep development of the SDK not too complex, we will drop Capacitor versions that are no longer maintained by Capacitor itself.

Fixes https://github.com/getsentry/sentry-capacitor/issues/893

pod issues will be fixed here https://github.com/getsentry/sentry-capacitor/pull/909

