### PR TITLE
 Fix pods

### DIFF
--- a/example/ionic-angular-v6/ios/App/App/capacitor.config.json
+++ b/example/ionic-angular-v6/ios/App/App/capacitor.config.json
@@ -9,6 +9,8 @@
 	"webDir": "www",
 	"packageClassList": [
 		"SentryCapacitor",
-		"SentryCapacitor"
+		"kSentryLevelNone",
+		"kSentryTransactionNameSourceCustom",
+		"SentryRRWebEvent"
 	]
 }

--- a/example/ionic-angular-v6/ios/App/Podfile.lock
+++ b/example/ionic-angular-v6/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (6.0.0):
     - CapacitorCordova
   - CapacitorCordova (6.0.0)
-  - Sentry/HybridSDK (8.50.1)
-  - SentryCapacitor (2.0.0-beta.1):
+  - Sentry/HybridSDK (8.51.1)
+  - "SentryCapacitor (2.0.0-beta.1+009a2329)":
     - Capacitor
-    - Sentry/HybridSDK (= 8.50.1)
+    - Sentry/HybridSDK (= 8.51.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 559d073c4ca6c27f8e7002c807eea94c3ba435a9
   CapacitorCordova: 8c4bfdf69368512e85b1d8b724dd7546abeb30af
-  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
-  SentryCapacitor: 05538a4a60e82e71861e08c144444ace7f91039c
+  Sentry: d950c807ffb8e966ebf019b546505a144d35d439
+  SentryCapacitor: aa8d77abfa12d9fc5477030aecf675a4fdb58b2b
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 

--- a/example/ionic-angular-v7/ios/App/App/capacitor.config.json
+++ b/example/ionic-angular-v7/ios/App/App/capacitor.config.json
@@ -8,6 +8,9 @@
 	},
 	"webDir": "www",
 	"packageClassList": [
+		"SentryRRWebEvent",
+		"kSentryTransactionNameSourceCustom",
+		"kSentryLevelNone",
 		"SentryCapacitor"
 	]
 }

--- a/example/ionic-angular-v7/ios/App/Podfile.lock
+++ b/example/ionic-angular-v7/ios/App/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorCordova (7.0.1)
-  - Sentry/HybridSDK (8.50.1)
-  - SentryCapacitor (2.0.0-beta.1):
+  - Sentry/HybridSDK (8.51.1)
+  - "SentryCapacitor (2.0.0-beta.1+009a2329)":
     - Capacitor
-    - Sentry/HybridSDK (= 8.50.1)
+    - Sentry/HybridSDK (= 8.51.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
-  SentryCapacitor: 1fed5bc6d2ac2edeab0131c28ed8b2d017fc1eda
+  Sentry: d950c807ffb8e966ebf019b546505a144d35d439
+  SentryCapacitor: b819ba0838b31f8905fe1e606f94a9d098a16ceb
 
 PODFILE CHECKSUM: e512db45f101b9092c98513e2bceba3944192dde
 

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -10,10 +10,10 @@ PODS:
     - Capacitor
   - CapacitorStatusBar (5.0.6):
     - Capacitor
-  - Sentry/HybridSDK (8.50.1)
-  - SentryCapacitor (2.0.0-beta.1):
+  - Sentry/HybridSDK (8.51.1)
+  - "SentryCapacitor (2.0.0-beta.1+009a2329)":
     - Capacitor
-    - Sentry/HybridSDK (= 8.50.1)
+    - Sentry/HybridSDK (= 8.51.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -51,8 +51,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 1fffc1217c7e64a472d7845be50fb0c2f7d4204c
   CapacitorKeyboard: ce5e01064cf57a2c05b32565310713b7fe6cc6f9
   CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
-  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
-  SentryCapacitor: 05538a4a60e82e71861e08c144444ace7f91039c
+  Sentry: d950c807ffb8e966ebf019b546505a144d35d439
+  SentryCapacitor: aa8d77abfa12d9fc5477030aecf675a4fdb58b2b
 
 PODFILE CHECKSUM: a972544de6bcfa1a17161b0b4ef85e6ee7586f79
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,7 +12,7 @@ end
 target 'Plugin' do
   capacitor_pods
 
-  pod 'Sentry/HybridSDK', '8.50.1'
+  pod 'Sentry/HybridSDK', '8.51.1'
 end
 
 target 'PluginTests' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorCordova (7.0.1)
-  - Sentry/HybridSDK (8.50.1)
+  - Sentry/HybridSDK (8.51.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Sentry/HybridSDK (= 8.50.1)
+  - Sentry/HybridSDK (= 8.51.1)
 
 SPEC REPOS:
   trunk:
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  Sentry: a6dd4a025b90f2caea04bfe10b2fe160a193072d
+  Sentry: d950c807ffb8e966ebf019b546505a144d35d439
 
-PODFILE CHECKSUM: e4a02eb188d200ec01ac2a041fa1e408619168c3
+PODFILE CHECKSUM: f31c8d5b6b1cf8404db46950d607df26fa859319
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
https://github.com/getsentry/sentry-capacitor/pull/895
The cocoa updater is not updating all the fields so CI tests are failing to pass..

This PR updates the pod files manually with the current Sentry Cocoa SDK.

An issue was open to track the main problem of the update cocoa  script https://github.com/getsentry/sentry-capacitor/issues/908

#skip-changelog.