### PR TITLE
feat(logs): Add support for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,44 @@
 
 ## Unreleased
 
+#### Features
+
+- Add experimental support for Log tracing ([#??](https://github.com/getsentry/sentry-capacitor/pull/???))
+
+To enable it add the following code to your Sentry Options:
+
+```typescript
+Sentry.init({
+  // other options...
+  _experiments: {
+    enableLogs: true,
+  },
+});
+```
+
+You can also filter the logs being collected by adding beforeSendLogs into `_experiments`
+
+```typescript
+Sentry.init({
+  // other options...
+  _experiments: {
+    enableLogs: true,
+    beforeSendLog: log => {
+      return log;
+    },
+  },
+});
+```
+
 ### Dependencies
 
 - Bump Android SDK from v8.13.2 to v8.13.3 ([#919](https://github.com/getsentry/sentry-capacitor/pull/919))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8133)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.13.2...8.13.3)
+
+### Self Hosted
+
+- It is recommended to use Sentry Self Hosted version `25.2.0` or new for Sentry Capacitor V2 or newer
 
 ## 2.0.0-beta.2
 

--- a/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
+++ b/android/src/main/java/io/sentry/capacitor/SentryCapacitor.java
@@ -144,6 +144,8 @@ public class SentryCapacitor extends Plugin {
                     }
                 }
 
+                options.getLogs().setEnabled(Boolean.TRUE.equals(capOptions.getBoolean("enableLogs", false)));
+
                 logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
             }
         );

--- a/example/ionic-angular-v6/src/app/app.module.ts
+++ b/example/ionic-angular-v6/src/app/app.module.ts
@@ -44,6 +44,12 @@ Sentry.init(
     // If the entire session is not sampled, use the below sample rate to sample
     // sessions when an error occurs.
     replaysOnErrorSampleRate: 1.0,
+    _experiments: {
+      enableLogs: true,
+      beforeSendLog: (log) => {
+        return log;
+      }
+    },
   },
   sentryAngularInit,
 );

--- a/example/ionic-angular-v6/src/app/tab2/tab2.page.html
+++ b/example/ionic-angular-v6/src/app/tab2/tab2.page.html
@@ -41,6 +41,13 @@
     </label>
 
     <label>
+      Capture Log
+      <ion-button (click)="captureLog()"
+        >CaptureLog</ion-button
+      >
+    </label>
+
+    <label>
       Close the SDK
       <ion-button (click)="close()"
         >Close the SDK</ion-button

--- a/example/ionic-angular-v6/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v6/src/app/tab2/tab2.page.ts
@@ -38,6 +38,16 @@ export class Tab2Page {
     );
   }
 
+  public captureLog(): void {
+    Sentry.logger.info('hello world capacitor');
+    Sentry.logger.warn('hello world capacitor');
+    Sentry.logger.error('hello world capacitor');
+    Sentry.logger.fatal('hello world capacitor', {
+      customAttribute: 1234,
+      complexAttribute: { logged: true}
+    });
+  }
+
   public close(): void {
     Sentry.close();
   }

--- a/example/ionic-angular-v7/src/app/app.module.ts
+++ b/example/ionic-angular-v7/src/app/app.module.ts
@@ -29,6 +29,12 @@ Sentry.init(
         blockAllMedia: true,
       }),
     ],
+    _experiments: {
+      enableLogs: true,
+      beforeSendLog: (log) => {
+        return log;
+      }
+    },
     // A release identifier
     release: '1.0.0',
     // A dist identifier

--- a/example/ionic-angular-v7/src/app/tab2/tab2.page.html
+++ b/example/ionic-angular-v7/src/app/tab2/tab2.page.html
@@ -41,6 +41,13 @@
     </label>
 
     <label>
+      Capture Log
+      <ion-button (click)="captureLog()"
+        >CaptureLog</ion-button
+      >
+    </label>
+
+    <label>
       Close the SDK
       <ion-button (click)="close()"
         >Close the SDK</ion-button

--- a/example/ionic-angular-v7/src/app/tab2/tab2.page.ts
+++ b/example/ionic-angular-v7/src/app/tab2/tab2.page.ts
@@ -38,6 +38,16 @@ export class Tab2Page {
     );
   }
 
+  public captureLog(): void {
+    Sentry.logger.info('hello world capacitor');
+    Sentry.logger.warn('hello world capacitor');
+    Sentry.logger.error('hello world capacitor');
+    Sentry.logger.fatal('hello world capacitor', {
+      customAttribute: 1234,
+      complexAttribute: { logged: true}
+    });
+  }
+
   public close(): void {
     Sentry.close();
   }

--- a/example/ionic-vue3/src/main.ts
+++ b/example/ionic-vue3/src/main.ts
@@ -52,6 +52,13 @@ Sentry.init({
   // Session Replay
   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+  _experiments: {
+    enableLogs: true,
+    beforeSendLog: (log) => {
+      return log;
+    }
+  },
+
 },
   // Forward the init method from @sentry/vue
   SentryVue.init

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export {
   startIdleSpan,
 } from '@sentry/core';
 
-export { replayIntegration, browserTracingIntegration, registerSpanErrorInstrumentation } from '@sentry/browser';
+export { replayIntegration, browserTracingIntegration, registerSpanErrorInstrumentation, logger } from '@sentry/browser';
 
 export { SDK_NAME, SDK_VERSION } from './version';
 export type { CapacitorOptions } from './options';

--- a/src/nativeOptions.ts
+++ b/src/nativeOptions.ts
@@ -1,6 +1,10 @@
 import { Capacitor } from '@capacitor/core';
 import type { CapacitorOptions } from './options';
 
+interface CapacitorLoggerOptions {
+  enableLogs: boolean
+}
+
 /**
  * Create a new CapacitorOption without any parameter that could crash the bridge (in short, not being a string, number or boolean).
  * some of the excluded parameters are: Integrations, app, vue, beforeSend, beforeBreadcrumb, integrations, defaultIntegrations, transport, tracesSampler.
@@ -36,6 +40,7 @@ export function FilterNativeOptions(
     // tunnel: options.tunnel: Only handled on the JavaScript Layer.
     enableCaptureFailedRequests: options.enableCaptureFailedRequests,
     ...iOSParameters(options),
+    ...LogParameters(options)
   };
 }
 
@@ -46,4 +51,12 @@ function iOSParameters(options: CapacitorOptions): CapacitorOptions {
       appHangTimeoutInterval: options.appHangTimeoutInterval,
     }
     : {};
+}
+
+function LogParameters(options: CapacitorOptions): CapacitorLoggerOptions | undefined {
+  // Only Web and Android implements log parameters initialization.
+  if (options._experiments?.enableLogs && Capacitor.getPlatform() === 'android') {
+    return { enableLogs: options._experiments?.enableLogs };
+  }
+  return undefined;
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -57,7 +57,7 @@ export const NATIVE = {
             : 'application/octet-stream';
         bytesPayload = [...itemPayload];
       } else {
-        bytesContentType = 'application/json';
+        bytesContentType = 'application/vnd.sentry.items.log+json';
         bytesPayload = utf8ToBytes(JSON.stringify(itemPayload));
       }
 

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -32,7 +32,7 @@ describe('nativeOptions', () => {
   test('invalid types not included', async () => {
     const nativeOptions = FilterNativeOptions(
       {
-        _experiments: [true],
+        _experiments: { key: true },
         _metadata: {},
         allowUrls: ['test'],
         attachStacktrace: true,
@@ -89,6 +89,7 @@ describe('nativeOptions', () => {
       // @ts-ignore allowed for testing.
       (typeof nativeOptions[key]) !== undefined)
 
+    // Since all parameters were invalid we can expect for an empty object.
     expect(keysFilter.toString()).toBe('');
   });
 
@@ -120,4 +121,29 @@ describe('nativeOptions', () => {
     expect(nativeOptions).toEqual(expectedOptions);
   });
 
+  test('Set logger on Android', async () => {
+    (Capacitor.getPlatform as jest.Mock).mockReturnValue('android');
+
+    const filteredOptions: CapacitorOptions = {
+      _experiments: { enableLogs : true}
+    };
+    const expectedOptions = {
+      // @ts-ignore
+      enableLogs : true
+    };
+
+    const nativeOptions = FilterNativeOptions(filteredOptions);
+    expect(JSON.stringify(nativeOptions)).toEqual(JSON.stringify(expectedOptions));
+  });
+
+  test('Ignore logger on iOS', async () => {
+    (Capacitor.getPlatform as jest.Mock).mockReturnValue('ios');
+
+    const filteredOptions: CapacitorOptions = {
+      _experiments: { enableLogs : true}
+    };
+
+    const nativeOptions = FilterNativeOptions(filteredOptions);
+    expect(nativeOptions).toEqual({});
+  });
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -193,7 +193,7 @@ describe('Tests Native Wrapper', () => {
       });
       const expectedItem = JSON.stringify({
         type: 'event',
-        content_type: 'application/json',
+        content_type: 'application/vnd.sentry.items.log+json',
         length: expectedNativeLength,
       });
       const expectedPayload = JSON.stringify({
@@ -250,7 +250,7 @@ describe('Tests Native Wrapper', () => {
       });
       const expectedItem = JSON.stringify({
         type: 'event',
-        content_type: 'application/json',
+        content_type: 'application/vnd.sentry.items.log+json',
         length: 116,
       });
       const expectedPayload = JSON.stringify({
@@ -324,7 +324,7 @@ describe('Tests Native Wrapper', () => {
       });
       const expectedItem = JSON.stringify({
         type: 'event',
-        content_type: 'application/json',
+        content_type: 'application/vnd.sentry.items.log+json',
         length: 172,
       });
       const expectedPayload = JSON.stringify({
@@ -381,7 +381,7 @@ describe('Tests Native Wrapper', () => {
       });
       const expectedItem = JSON.stringify({
         type: 'event',
-        content_type: 'application/json',
+        content_type: 'application/vnd.sentry.items.log+json',
         length: 172,
       });
       const expectedPayload = JSON.stringify({


### PR DESCRIPTION
This PR enables the support for logs on Sentry Capacitor.
Additionally, it also exposes the logger integration into capacitor to simplify the documentation of it.

## How to enable:

To enable it, add the following code to your Sentry Options:

```typescript
Sentry.init({
  // other options...
  _experiments: {
    enableLogs: true,
  },
});
```

You can also filter the logs being collected by adding beforeSendLogs into `_experiments`

```typescript
Sentry.init({
  // other options...
  _experiments: {
    enableLogs: true,
    beforeSendLog: log => {
      return log;
    },
  },
});
```

## How to use

simply import logger from `@sentry/capacitor` and capture a log with it, example:
```typescript
import { logger } from '@sentry/capacitor';

    logger.info('hello world capacitor');
    logger.warn('hello world capacitor');
    logger.error('hello world capacitor');
    logger.fatal('hello world capacitor', {
      customAttribute: 1234,
      complexAttribute: { logged: true}
    });

```