### PR TITLE
Prepare V2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Sentry.init({
   },
 });
 
-### Break Change
+### Breaking Change
 
 - Drop support for Capacitor 3, 4 and 5. ([#907](https://github.com/getsentry/sentry-capacitor/pull/907))
 


### PR DESCRIPTION
Lets update the changelog in order to prepare for the V2 release.

Close #913

#skip-changelog.