### PR TITLE
Fix: Can't find BrowserTransportOptions type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > [migration guide](https://docs.sentry.io/platforms/javascript/guides/capacitor/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- TypeScript build with strict rules couldn't find BrowserTransportOptions type ([#934](https://github.com/getsentry/sentry-capacitor/pull/934))
+
 ## 2.0.0
 
 #### Features

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,8 @@
-import type { BrowserOptions } from '@sentry/browser';
-import type { BrowserTransportOptions } from '@sentry/browser/build/npm/types/transports/types'; // Path changed on 8.13.0
+import type { BrowserOptions, makeFetchTransport } from '@sentry/browser';
 import type { ClientOptions } from '@sentry/core';
+
+// Direct reference of BrowserTransportOptions is not compatible with strict builds of latest versions of Typescript 5.
+type BrowserTransportOptions = Parameters<typeof makeFetchTransport>[0];
 
 export interface BaseCapacitorOptions {
   /**


### PR DESCRIPTION
On strict builds, the original reference of `BrowserTransportOptions` is not accepted.

By using `Parameters<typeof makeFetchTransport>[0]` we are able to get the original type of `BrowserTransportOptions` while keeping it compatible with strict builds of Typescript.

Same fix already exists on React Native: https://github.com/getsentry/sentry-react-native/blob/ffab99479d130e00dec3443403629a9a99f29a64/packages/core/src/js/options.ts#L11

Fixes: https://github.com/getsentry/sentry-capacitor/issues/933