### PR TITLE
Add missing version 1.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,18 @@ Sentry.init({
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/9.0.0/CHANGELOG.md#900)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/8.55.0...9.0.0)
 
+## 1.5.0
+
+### Fixes
+
+- Google Play’s 16 KB page size compatibility requirement ([#930](https://github.com/getsentry/sentry-capacitor/pull/930))
+
+### Dependencies
+
+- Bump Android SDK from v7.16.0 to v7.22.5 ([#930](https://github.com/getsentry/sentry-capacitor/pull/930))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/7.22.5/CHANGELOG.md)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.16.0...7.22.5)
+
 ## 1.4.0
 
 ### Dependencies


### PR DESCRIPTION
https://github.com/getsentry/sentry-capacitor/blob/1.5.0/CHANGELOG.md
This version was hotfix and the changelog was missing from the changelog from the main branch

#skip-changelog