### PR TITLE
Fix native options test

### DIFF
--- a/src/integrations/sdkinfo.ts
+++ b/src/integrations/sdkinfo.ts
@@ -31,7 +31,7 @@ export const sdkInfoIntegration = (): Integration => {
       }
     }
   };
-};
+}
 
 async function processEvent(event: Event): Promise<Event> {
   // The native SDK info package here is only used on iOS as `beforeSend` is not called on `captureEnvelope`.

--- a/src/integrations/sdkinfo.ts
+++ b/src/integrations/sdkinfo.ts
@@ -31,7 +31,7 @@ export const sdkInfoIntegration = (): Integration => {
       }
     }
   };
-}
+};
 
 async function processEvent(event: Event): Promise<Event> {
   // The native SDK info package here is only used on iOS as `beforeSend` is not called on `captureEnvelope`.

--- a/test/extensions/sentryCapacitorJest.ts
+++ b/test/extensions/sentryCapacitorJest.ts
@@ -1,0 +1,8 @@
+import { Capacitor } from '@capacitor/core';
+
+// Must be imported after the line that mocks Capacitor.
+export function expectPlatformWithReturn(platform: string) {
+  const mockGetPlatform = Capacitor.getPlatform as jest.Mock;
+  expect(mockGetPlatform).toHaveBeenCalled();
+  expect(mockGetPlatform).toHaveReturnedWith(platform);
+}

--- a/test/integrations/sdkinfo.test.ts
+++ b/test/integrations/sdkinfo.test.ts
@@ -30,8 +30,8 @@ jest.mock('../../src/wrapper', () => {
 
 describe('Sdk Info', () => {
   afterEach(() => {
-
     NATIVE.platform = 'ios';
+    jest.clearAllMocks();
   });
 
   it('Adds native package and javascript platform to event on iOS', async () => {
@@ -40,7 +40,7 @@ describe('Sdk Info', () => {
     const processedEvent = await processEvent(mockEvent);
 
     expect(processedEvent?.sdk?.packages).toEqual(expect.arrayContaining([mockiOSPackage]));
-    expect(processedEvent?.platform === 'javascript');
+    expect(processedEvent?.platform).toBe('javascript');
     expect(mockedFetchNativeSdkInfo).toHaveBeenCalledTimes(1);
   });
 

--- a/test/integrations/sdkinfo.test.ts
+++ b/test/integrations/sdkinfo.test.ts
@@ -31,7 +31,6 @@ jest.mock('../../src/wrapper', () => {
 describe('Sdk Info', () => {
   afterEach(() => {
     NATIVE.platform = 'ios';
-    jest.clearAllMocks();
   });
 
   it('Adds native package and javascript platform to event on iOS', async () => {

--- a/test/mocks/capacitor.ts
+++ b/test/mocks/capacitor.ts
@@ -1,0 +1,13 @@
+// Shared mock for @capacitor/core to avoid conflicts between test files
+export const mockCapacitor = {
+  WebPlugin: jest.fn(),
+  registerPlugin: jest.fn(),
+  Capacitor: {
+    isPluginAvailable: jest.fn(() => true),
+    getPlatform: jest.fn(() => 'android'),
+  },
+};
+
+export const setupCapacitorMock = () => {
+  jest.doMock('@capacitor/core', () => mockCapacitor);
+};

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -6,13 +6,16 @@ import { FilterNativeOptions } from '../src/nativeOptions';
 // Mock the Capacitor module
 jest.mock('@capacitor/core', () => ({
   Capacitor: {
-    getPlatform: jest.fn()
+    getPlatform: jest.fn(() => {
+      throw new Error('Mocked error from getPlatform');
+    }),
   }
 }));
 
-
 describe('nativeOptions', () => {
-
+  beforeEach(() => {
+    jest.resetAllMocks(); // reset mock history
+  });
   test('enableWatchdogTerminationTracking is set when defined', async () => {
     const nativeOptions = FilterNativeOptions(
       {

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -105,7 +105,7 @@ describe('nativeOptions', () => {
       enableAppHangTracking: true,
       appHangTimeoutInterval: 123
     };
-    const nativeOptions = FilterNativeOptions(expectedOptions);
+    const nativeOptions = FilterNativeOptions({ ...expectedOptions });
     expect(JSON.stringify(nativeOptions)).toEqual(JSON.stringify(expectedOptions));
   });
 

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -5,7 +5,6 @@ import { setupCapacitorMock } from './mocks/capacitor';
 
 setupCapacitorMock();
 
-// Now import after the mock is set up
 import { Capacitor } from '@capacitor/core';
 import { FilterNativeOptions } from '../src/nativeOptions';
 import { expectPlatformWithReturn } from './extensions/sentryCapacitorJest';

--- a/test/nativeOptions.test.ts
+++ b/test/nativeOptions.test.ts
@@ -8,6 +8,8 @@ setupCapacitorMock();
 // Now import after the mock is set up
 import { Capacitor } from '@capacitor/core';
 import { FilterNativeOptions } from '../src/nativeOptions';
+import { expectPlatformWithReturn } from './extensions/sentryCapacitorJest';
+
 
 describe('nativeOptions', () => {
   const mockGetPlatform = Capacitor.getPlatform as jest.Mock;
@@ -108,10 +110,9 @@ describe('nativeOptions', () => {
       enableAppHangTracking: true,
       appHangTimeoutInterval: 123
     };
-    const nativeOptions = FilterNativeOptions({ ...expectedOptions });
+    const nativeOptions = FilterNativeOptions(expectedOptions);
 
-    // Verify that FilterNativeOptions called getPlatform and got 'ios'
-    expect(mockGetPlatform).toHaveBeenCalled();
+    expectPlatformWithReturn('ios');
     expect(JSON.stringify(nativeOptions)).toEqual(JSON.stringify(expectedOptions));
   });
 
@@ -127,8 +128,7 @@ describe('nativeOptions', () => {
       }
     });
 
-    // Verify that FilterNativeOptions called getPlatform and got 'android'
-    expect(mockGetPlatform).toHaveBeenCalled();
+    expectPlatformWithReturn('android');
     expect(nativeOptions).toEqual(expectedOptions);
   });
 
@@ -144,8 +144,7 @@ describe('nativeOptions', () => {
 
     const nativeOptions = FilterNativeOptions(filteredOptions);
 
-    // Verify that FilterNativeOptions called getPlatform and got 'android'
-    expect(mockGetPlatform).toHaveBeenCalled();
+    expectPlatformWithReturn('android');
     expect(JSON.stringify(nativeOptions)).toEqual(JSON.stringify(expectedOptions));
   });
 
@@ -157,8 +156,7 @@ describe('nativeOptions', () => {
 
     const nativeOptions = FilterNativeOptions(filteredOptions);
 
-    // Verify that FilterNativeOptions called getPlatform and got 'ios'
-    expect(mockGetPlatform).toHaveBeenCalled();
+    expectPlatformWithReturn('ios');
     expect(nativeOptions).toEqual({});
   });
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -2,32 +2,15 @@
 import type { Envelope, EventEnvelope, EventItem, SeverityLevel, TransportMakeRequestResponse } from '@sentry/core';
 import {createEnvelope, dropUndefinedKeys, logger} from '@sentry/core';
 import { utf8ToBytes } from '../src/vendor';
-import { NATIVE } from '../src/wrapper';
 
 let getStringBytesLengthValue = 1;
 
-function NumberArrayToString(numberArray: number[]): string {
-  return new TextDecoder().decode(new Uint8Array(numberArray).buffer);
-}
+// Use shared mock to avoid conflicts
+import { setupCapacitorMock } from './mocks/capacitor';
 
-jest.mock(
-  '@capacitor/core',
-  () => {
-    const original = jest.requireActual('@capacitor/core');
+setupCapacitorMock();
 
-    return {
-      WebPlugin: original.WebPlugin,
-      registerPlugin: jest.fn(),
-      Capacitor: {
-        isPluginAvailable: jest.fn(() => true),
-        getPlatform: jest.fn(() => 'android'),
-      },
-    };
-  },
-  /* virtual allows us to mock modules that aren't in package.json */
-  { virtual: true },
-);
-
+// Mock the plugin before importing wrapper
 jest.mock('../src/plugin', () => {
   return {
     SentryCapacitor: {
@@ -65,7 +48,13 @@ jest.mock('../src/plugin', () => {
   };
 });
 
+// Now import after mocks are set up
 import { SentryCapacitor } from '../src/plugin';
+import { NATIVE } from '../src/wrapper';
+
+function NumberArrayToString(numberArray: number[]): string {
+  return new TextDecoder().decode(new Uint8Array(numberArray).buffer);
+}
 
 beforeEach(() => {
   getStringBytesLengthValue = 1;


### PR DESCRIPTION
#skip-changelog

# Problem
There was an intermittent flakiness that was more visible on Github CI than local, all started with 1276dfbe7c618b0e6b6fe7661f7f88dd19add64c, the additional tests probably made it more flaky than usual.

# Changes Made
The mock of Capacitor was standardized in a single file to avoid contamination across test files, the usage of doMock also helped to make sure the timings of tests works correctly.