### PR TITLE
Ref: Refer to SPM Sentry Capacitor on Sample apps

### DIFF
--- a/example/ionic-angular-v6/ios/App/App/capacitor.config.json
+++ b/example/ionic-angular-v6/ios/App/App/capacitor.config.json
@@ -8,9 +8,6 @@
 	},
 	"webDir": "www",
 	"packageClassList": [
-		"SentryCapacitor",
-		"kSentryLevelNone",
-		"kSentryTransactionNameSourceCustom",
-		"SentryRRWebEvent"
+		"SentryCapacitorPlugin"
 	]
 }

--- a/example/ionic-angular-v7/ios/App/App/capacitor.config.json
+++ b/example/ionic-angular-v7/ios/App/App/capacitor.config.json
@@ -8,9 +8,6 @@
 	},
 	"webDir": "www",
 	"packageClassList": [
-		"SentryRRWebEvent",
-		"kSentryTransactionNameSourceCustom",
-		"kSentryLevelNone",
-		"SentryCapacitor"
+		"SentryCapacitorPlugin"
 	]
 }

--- a/example/ionic-angular-v7/ios/App/CapApp-SPM/Package.swift
+++ b/example/ionic-angular-v7/ios/App/CapApp-SPM/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
+let package = Package(
+    name: "CapApp-SPM",
+    platforms: [.iOS(.v14)],
+    products: [
+        .library(
+            name: "CapApp-SPM",
+            targets: ["CapApp-SPM"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "7.0.1"),
+        .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
+    ],
+    targets: [
+        .target(
+            name: "CapApp-SPM",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "SentryCapacitor", package: "SentryCapacitor")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
Since Sentry Capacitor supports SPM, we no longer need to rely on auto generated SPM packages.
This PR clears up the previously auto generated files to use the correct SPM package for Sentry Capacitor.

#skip-changelog.