### PR TITLE
Fix: internal options init was changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@
 > [migration guide](https://docs.sentry.io/platforms/javascript/guides/capacitor/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- iOS build error due to recent changes with Native Sentry Options ([#980](https://github.com/getsentry/sentry-capacitor/pull/980))
+
 ## 2.3.0
+
+> [!WARNING]
+> This release contains an issue where iOS builds will fail, please opt for a lower version or version 2.3.1 or newer.
+> See issue [#4598](https://github.com/getsentry/sentry-capacitor/issues/979) for more details.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 > [!WARNING]
 > This release contains an issue where iOS builds will fail, please opt for a lower version or version 2.3.1 or newer.
-> See issue [#4598](https://github.com/getsentry/sentry-capacitor/issues/979) for more details.
+> See issue [#979](https://github.com/getsentry/sentry-capacitor/issues/979) for more details.
 
 ### Features
 

--- a/example/ionic-angular-v6/ios/App/Podfile.lock
+++ b/example/ionic-angular-v6/ios/App/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - CapacitorCordova
   - CapacitorCordova (6.0.0)
   - Sentry/HybridSDK (8.55.0)
-  - "SentryCapacitor (2.0.0+116fb98b)":
+  - "SentryCapacitor (2.3.0+bfea6c5f)":
     - Capacitor
     - Sentry/HybridSDK (= 8.55.0)
 
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 559d073c4ca6c27f8e7002c807eea94c3ba435a9
   CapacitorCordova: 8c4bfdf69368512e85b1d8b724dd7546abeb30af
-  Sentry: 59993bffde4a1ac297ba6d268dc4bbce068d7c1b
-  SentryCapacitor: 493a329bf9145f60afb55cd65f1f363c5ef6e665
+  Sentry: f7dddfabe691274d6d630f04621e1345f9d6b9e0
+  SentryCapacitor: 02551ec86877a5fda41b410b2700d5ca47ba1048
 
 PODFILE CHECKSUM: 618eb4d85f9b0c9e5a37fffa86a92d1569bd6800
 

--- a/example/ionic-angular-v7/ios/App/Podfile.lock
+++ b/example/ionic-angular-v7/ios/App/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - CapacitorCordova
   - CapacitorCordova (7.0.1)
   - Sentry/HybridSDK (8.55.0)
-  - "SentryCapacitor (2.0.0+116fb98b)":
+  - "SentryCapacitor (2.3.0+bfea6c5f)":
     - Capacitor
     - Sentry/HybridSDK (= 8.55.0)
 
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  Sentry: 59993bffde4a1ac297ba6d268dc4bbce068d7c1b
-  SentryCapacitor: a08f44d64511f87cb05391f48d9e6722bc03d88b
+  Sentry: f7dddfabe691274d6d630f04621e1345f9d6b9e0
+  SentryCapacitor: fb23a560339c3435600961286f2e656e150e8f8d
 
 PODFILE CHECKSUM: e512db45f101b9092c98513e2bceba3944192dde
 

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - CapacitorStatusBar (5.0.6):
     - Capacitor
   - Sentry/HybridSDK (8.55.0)
-  - "SentryCapacitor (2.0.0+116fb98b)":
+  - "SentryCapacitor (2.3.0+bfea6c5f)":
     - Capacitor
     - Sentry/HybridSDK (= 8.55.0)
 
@@ -51,8 +51,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 1fffc1217c7e64a472d7845be50fb0c2f7d4204c
   CapacitorKeyboard: ce5e01064cf57a2c05b32565310713b7fe6cc6f9
   CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
-  Sentry: 59993bffde4a1ac297ba6d268dc4bbce068d7c1b
-  SentryCapacitor: 493a329bf9145f60afb55cd65f1f363c5ef6e665
+  Sentry: f7dddfabe691274d6d630f04621e1345f9d6b9e0
+  SentryCapacitor: 02551ec86877a5fda41b410b2700d5ca47ba1048
 
 PODFILE CHECKSUM: a972544de6bcfa1a17161b0b4ef85e6ee7586f79
 

--- a/ios/Sources/SentryCapacitorPlugin/SentryCapacitorPlugin.swift
+++ b/ios/Sources/SentryCapacitorPlugin/SentryCapacitorPlugin.swift
@@ -70,8 +70,7 @@ public class SentryCapacitorPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         do {
-            let options = try Options.init(dict: optionsDict)
-
+            let options = try SentryOptionsInternal.initWithDict(optionsDict)
             let sdkVersion = PrivateSentrySDKOnly.getSdkVersionString()
             PrivateSentrySDKOnly.setSdkName(nativeSdkName, andVersionString: sdkVersion)
 


### PR DESCRIPTION
Sentry options initialization has changed on newer versions of Sentry Cocoa, this PR fixes it by using an alternative method of initializing Sentry Options.

Fixes: https://github.com/getsentry/sentry-capacitor/issues/979