### PR TITLE
Add Security vulnerability warning to sample apps.

### DIFF
--- a/example/ionic-angular-v6/README.md
+++ b/example/ionic-angular-v6/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This Sample code may contain security vulnerabilities, should never be used in production, and exists only for illustrative purposes.
+
 # Instructions for using the example app
 
 ## Add the local SDK from yalc

--- a/example/ionic-angular-v7/README.md
+++ b/example/ionic-angular-v7/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This Sample code may contain security vulnerabilities, should never be used in production, and exists only for illustrative purposes.
+
 # Instructions for using the example app
 
 ## Add the local SDK from yalc

--- a/example/ionic-vue3/README.md
+++ b/example/ionic-vue3/README.md
@@ -1,0 +1,2 @@
+> [!WARNING]
+> This Sample code may contain security vulnerabilities, should never be used in production, and exists only for illustrative purposes.


### PR DESCRIPTION
Sample apps uses old dependencies that may contain security vulnerabilities. Those sample apps are only used for demonstration purpose and Integration tests.

This only adds a warning that those sample apps shouldn't be used in production.

If any security vulnerability exists on the sample apps, they will in any way affect the end user SDK of Sentry Capacitor.


Based on https://github.com/getsentry/sentry-cordova/pull/386