### PR TITLE
Update CHANGELOG.md with iOS 26 mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Unreleased
 
-## Fixes
+## Feature
 
 - Support for iOS 26 ([#967](https://github.com/getsentry/sentry-capacitor/pull/967))
 


### PR DESCRIPTION
By bumping to the latest SDK of Sentry Cocoa we also add support to iOS 26.

This PR only adds a new mention to support to iOS 26 so users know when support was added to Sentry Capacitor.

#skip-changelog.