### PR TITLE
fix: do not hardcode the iphone version to be tested.

### DIFF
--- a/.github/workflows/sample-build.yml
+++ b/.github/workflows/sample-build.yml
@@ -120,7 +120,7 @@ jobs:
                      -scheme App \
                      -configuration Debug \
                      -sdk iphonesimulator \
-                     -destination 'platform=iOS Simulator,name=$SIMULATOR_NAME' \
+                     -destination "platform=iOS Simulator,name=$SIMULATOR_NAME" \
                      build | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Upload iOS build logs


### PR DESCRIPTION
By hard-coding the iPhone version, we have the occasional error where the iPhone is not available on future versions.
This fix allows us to always select the latest available iPhone from Github VM.

#skip-changelog.