### PR TITLE
chore: X handle update

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,5 @@ Sentry.captureEvent({
 * [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-capacitor.svg)](https://github.com/getsentry/sentry-capacitor/discussions)
 * [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)
 * [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](https://stackoverflow.com/questions/tagged/sentry)
-* [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
+* [![X Follow](https://img.shields.io/twitter/follow/sentry?label=sentry&style=social)](https://x.com/intent/follow?screen_name=sentry)
+


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry-react-native/pull/5347 since the X handle has changed

#skip-changelog