### PR TITLE
Remove V3 from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,6 @@ For more informations, please go to the following link: https://docs.sentry.io/p
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.27.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/9.46.0...10.27.0)
 
-## V3
-
 ## 2.4.1
 
 ### Fixes


### PR DESCRIPTION
Removed version header for V3 from CHANGELOG.

#skip-changelog.