### PR TITLE
Update capacitor-spm to v8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["SentryCapacitorPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.56.2")
     ],
     targets: [


### PR DESCRIPTION
This updates the `https://github.com/ionic-team/capacitor-swift-pm.git` dependency to v8 for capacitor 8