### PR TITLE
chore: ignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ sentry-capacitor-v*.tgz
 
 #sentry tokens
 *.sentryclirc
+
+# Local Claude Code settings that should not be committed
+.claude/settings.local.json


### PR DESCRIPTION
Ignore .claude/settings.local.json as these are local settings not intended for version control.

#skip-changelog