### PR TITLE
Fix: Danger not working

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review, labeled, unlabeled]
 
-permissions:
-  contents: write
-  pull-requests: write
 jobs:
   danger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previous runs were throwing :green_circle: on CI, despite not having a changelog. 
The issue was introduced by https://github.com/getsentry/sentry-capacitor/pull/1072/files#diff-9ed6d3c8f52cf7b6862dd9628741eda3dbcd3683b1485977c483b6571e989904
Where it complains about 
```
Could not add a commit status, the GitHub token for Danger does not have access rights.
If the build fails, then danger will use a failing exit code.
```

A 'fix' was introduced by adding `statuses` but that only made the PR to always pass despite the missing changelog.

Without the permissions, the danger action works correctly.

Question: Do we really need the permissions here? If so, do we need to update the token on this repo?