### PR TITLE
ci(release): Fix changelog-preview permissions.

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -8,7 +8,7 @@ on:
     - edited
     - labeled
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
The changelog-preview reusable workflow now requires `statuses: write`
permission to function correctly with GitHub App installations that
declare permissions statically.