### PR TITLE
Ref: Create pull_request_template.md for PR submissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## :loudspeaker: Type of change
+<!--- Put an `x` in the boxes that apply -->
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Enhancement
+- [ ] Refactoring
+
+
+## :scroll: Description
+<!--- Describe your changes in detail -->
+
+
+## :bulb: Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+
+## :green_heart: How did you test it?
+
+
+## :pencil: Checklist
+<!--- Put an `x` in the boxes that apply -->
+- [ ] I added tests to verify changes
+- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
+- [ ] I updated the docs if needed.
+- [ ] I updated the wizard if needed.
+- [ ] All tests passing
+- [ ] No breaking changes
+
+## :crystal_ball: Next steps


### PR DESCRIPTION
Add a pull request template to standardize submissions.

It's the same template used in https://github.com/getsentry/sentry-react-native/blob/main/.github/pull_request_template.md 

#skip-changelog.