### PR TITLE
Fix(V3): Add missing httpContextIntegration integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- prettier-ignore-start -->
 > [!IMPORTANT]
-> If you are upgrading to the `2.x` versions of the SDK from `1.x` or lower, make sure you follow our
+> If you are upgrading to the `3.x` versions of the SDK from `2.x` or lower, make sure you follow our
 > [migration guide](https://docs.sentry.io/platforms/javascript/guides/capacitor/migration/) first.
 <!-- prettier-ignore-end -->
 
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Add missing `httpContextIntegration`
+- Add missing `httpContextIntegration` integration by default when using your project on the browser. ([#1119](https://github.com/getsentry/sentry-capacitor/pull/1119))
 
 ## 3.0.0-rc.1
 

--- a/src/integrations/default.ts
+++ b/src/integrations/default.ts
@@ -1,4 +1,4 @@
-import { breadcrumbsIntegration, browserApiErrorsIntegration, browserSessionIntegration, globalHandlersIntegration } from '@sentry/browser';
+import { breadcrumbsIntegration, browserApiErrorsIntegration, browserSessionIntegration, globalHandlersIntegration, httpContextIntegration } from '@sentry/browser';
 import { dedupeIntegration, eventFiltersIntegration, functionToStringIntegration, type Integration, linkedErrorsIntegration } from '@sentry/core';
 import type { CapacitorOptions } from '../options';
 import { deviceContextIntegration } from './devicecontext';
@@ -24,6 +24,9 @@ export function getDefaultIntegrations(
   if (options.enableNative) {
     integrations.push(deviceContextIntegration());
     integrations.push(logEnricherIntegration());
+  }
+  else {
+    integrations.push(httpContextIntegration());
   }
 
   // @sentry/browser integrations


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Integration was added prior V3, this change makes it so that when using Web Capacitor, browser/OS info are attached to events/replays/spans.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Client was missing browser and os data from browser with Capacitor.

## :green_heart: How did you test it?

Sample App.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
