### PR TITLE
fix(ci): Use composite action syntax for updater workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,47 +15,52 @@ permissions:
   pull-requests: write
 jobs:
   android:
-    uses: getsentry/github-workflows/updater@v3
-    with:
-      path: scripts/update-android.sh
-      name: Android SDK
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/update-android.sh
+          name: Android SDK
+          pr-strategy: update
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   cocoa:
-    uses: getsentry/github-workflows/updater@v3
-    with:
-      path: scripts/update-cocoa.sh
-      name: Cocoa SDK
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/update-cocoa.sh
+          name: Cocoa SDK
+          pr-strategy: update
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   javascript:
-    uses: getsentry/github-workflows/updater@v3
-    with:
-      path: scripts/update-javascript.sh
-      name: JavaScript SDK
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/update-javascript.sh
+          name: JavaScript SDK
+          pr-strategy: update
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   javascript-siblings:
-    uses: getsentry/github-workflows/updater@v3
-    with:
-      path: scripts/update-javascript-siblings.sh
-      name: JavaScript Sibling SDKs
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/update-javascript-siblings.sh
+          name: JavaScript Sibling SDKs
+          pr-strategy: update
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   wizard:
-    uses: getsentry/github-workflows/updater@v3
-    with:
-      path: scripts/update-wizard.sh
-      name: Wizard
-      pr-strategy: update
-      changelog-entry: false
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/update-wizard.sh
+          name: Wizard
+          pr-strategy: update
+          changelog-entry: false
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
The updater is a composite action, not a reusable workflow, so it must be used as a step within a job rather than with job-level `uses:`.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
<!--- Describe your changes in detail -->

:robot: 
  The update-deps.yml workflow was failing because it used job-level uses: syntax to reference getsentry/github-workflows/updater@v3. This      
  syntax is only valid for reusable workflows (.yml files in .github/workflows/).                                                               
                                                                                                                                                
  However, updater is a composite action (defined by action.yml in a directory), which must be invoked as a step within a job:                  
                                                                                                                                                
  # Before (incorrect - reusable workflow syntax)                                                                                               
  jobs:                                                                                                                                         
    android:                                                                                                                                    
      uses: getsentry/github-workflows/updater@v3                                                                                               
                                                                                                                                                
  # After (correct - composite action syntax)                                                                                                   
  jobs:                                                                                                                                         
    android:                                                                                                                                    
      runs-on: ubuntu-latest                                                                                                                    
      steps:                                                                                                                                    
        - uses: getsentry/github-workflows/updater@v3                                                                                           
                                                                                                                                                
  Also changed secrets: api-token: to the correct input ssh-key: to match the action's expected parameters.                                     

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CI wasn't making bump PRs

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog