### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -87,7 +87,7 @@ jobs:
           yalc publish
 
       - name: Upload yalc package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: yalc-package
           if-no-files-found: error
@@ -146,7 +146,7 @@ jobs:
       - name: Pack
         run: yarn pack
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4.1.0
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ github.sha }}
           path: |

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   changelog-preview:
-    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # v2
     secrets: inherit

--- a/.github/workflows/ready-to-merge-workflow.yml
+++ b/.github/workflows/ready-to-merge-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check for exact 'ready-to-merge' label
         if: ${{ github.event_name == 'pull_request' }}
         id: check-label
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const expectedLabel = 'ready-to-merge';

--- a/.github/workflows/sample-build.yml
+++ b/.github/workflows/sample-build.yml
@@ -65,7 +65,7 @@ jobs:
         run: yarn  global add @ionic/cli
 
       - name: Download Sentry Capacitor package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: yalc-package
           path: ~/.yalc/packages/@sentry/capacitor/
@@ -81,7 +81,7 @@ jobs:
         run: yarn run bump:${{ matrix.bump }}
 
       - name: Set up Java ${{ matrix.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: ${{ matrix.JAVA_VERSION }}
@@ -103,7 +103,7 @@ jobs:
         run: ./gradlew --no-daemon assembleDebug
 
       - name: Upload Android APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.bump }}-android-apk
           if-no-files-found: warn
@@ -134,7 +134,7 @@ jobs:
                      build | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Upload iOS build logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.bump }}-ios-build-logs
           if-no-files-found: warn

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,7 +17,7 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
         with:
           path: scripts/update-android.sh
           name: Android SDK
@@ -27,7 +27,7 @@ jobs:
   cocoa:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
         with:
           path: scripts/update-cocoa.sh
           name: Cocoa SDK
@@ -37,7 +37,7 @@ jobs:
   javascript:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
         with:
           path: scripts/update-javascript.sh
           name: JavaScript SDK
@@ -47,7 +47,7 @@ jobs:
   javascript-siblings:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
         with:
           path: scripts/update-javascript-siblings.sh
           name: JavaScript Sibling SDKs
@@ -57,7 +57,7 @@ jobs:
   wizard:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
         with:
           path: scripts/update-wizard.sh
           name: Wizard


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)