### PR TITLE
Ref: rollback 3.2.1 deprecations

### DIFF
--- a/example/ionic-angular-v7/src/app/app.module.ts
+++ b/example/ionic-angular-v7/src/app/app.module.ts
@@ -14,8 +14,7 @@ import { environment } from '../environments/environment';
 // ATTENTION: Change the DSN below with your own to see the events in Sentry. Get one at sentry.io
 Sentry.init(
   {
-    dsn:
-      'https://4079af8b316240ea9453eb0a23b715cc@o447951.ingest.sentry.io/5522756',
+    dsn: 'https://4079af8b316240ea9453eb0a23b715cc@o447951.ingest.sentry.io/5522756',
     // An array of strings or regexps that'll be used to ignore specific errors based on their type/message
     ignoreErrors: [/MiddleEarth_\d\d/, 'RangeError'],
     // To see what the Sentry SDK is doing; Helps when setting things up
@@ -25,7 +24,7 @@ Sentry.init(
     // Use the tracing integration to see traces and add performance monitoring
     _experiments: {
       enableMetrics: true,
-      beforeSendMetric: (metric) => {
+      beforeSendMetric: metric => {
         return metric;
       },
     },
@@ -36,11 +35,11 @@ Sentry.init(
         blockAllMedia: true,
       }),
       Sentry.spotlightIntegration({
-        sidecarUrl:  environment.spotlightSidecarUrl,
+        sidecarUrl: environment.spotlightSidecarUrl,
       }),
     ],
     enableLogs: true,
-    beforeSendLog: (log) => {
+    beforeSendLog: log => {
       return log;
     },
     // A release identifier
@@ -52,12 +51,6 @@ Sentry.init(
     // We recommend adjusting this value in production, or using tracesSampler
     // for finer control
     tracesSampleRate: 1.0,
-    // This sets the sample rate to be 10%. You may want this to be 100% while
-    // in development and sample at a lower rate in production
-    replaysSessionSampleRate: 0.1,
-    // If the entire session is not sampled, use the below sample rate to sample
-    // sessions when an error occurs.
-    replaysOnErrorSampleRate: 1.0,
   },
   sentryAngularInit,
 );
@@ -75,6 +68,6 @@ Sentry.init(
       useValue: createErrorHandler(),
     },
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/example/ionic-angular-v8/src/app/app.module.ts
+++ b/example/ionic-angular-v8/src/app/app.module.ts
@@ -14,8 +14,7 @@ import { environment } from '../environments/environment';
 // ATTENTION: Change the DSN below with your own to see the events in Sentry. Get one at sentry.io
 Sentry.init(
   {
-    dsn:
-      'https://4079af8b316240ea9453eb0a23b715cc@o447951.ingest.sentry.io/5522756',
+    dsn: 'https://4079af8b316240ea9453eb0a23b715cc@o447951.ingest.sentry.io/5522756',
     // An array of strings or regexps that'll be used to ignore specific errors based on their type/message
     ignoreErrors: [/MiddleEarth_\d\d/, 'RangeError'],
     // To see what the Sentry SDK is doing; Helps when setting things up
@@ -25,7 +24,7 @@ Sentry.init(
     // Use the tracing integration to see traces and add performance monitoring
     _experiments: {
       enableMetrics: true,
-      beforeSendMetric: (metric) => {
+      beforeSendMetric: metric => {
         return metric;
       },
     },
@@ -40,7 +39,7 @@ Sentry.init(
       }),
     ],
     enableLogs: true,
-    beforeSendLog: (log) => {
+    beforeSendLog: log => {
       return log;
     },
     // A release identifier
@@ -52,11 +51,6 @@ Sentry.init(
     // We recommend adjusting this value in production, or using tracesSampler
     // for finer control
     tracesSampleRate: 1.0,
-    // This sets the sample rate to be 10%. You may want this to be 100% while
-    // in development and sample at a lower rate in production
-    replaysSessionSampleRate: 1.0,    // If the entire session is not sampled, use the below sample rate to sample
-    // sessions when an error occurs.
-    replaysOnErrorSampleRate: 1.0,
   },
   sentryAngularInit,
 );
@@ -74,6 +68,6 @@ Sentry.init(
       useValue: createErrorHandler(),
     },
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/example/ionic-vue3/src/main.ts
+++ b/example/ionic-vue3/src/main.ts
@@ -1,5 +1,5 @@
-import { createApp } from 'vue'
-import App from './App.vue'
+import { createApp } from 'vue';
+import App from './App.vue';
 import router from './router';
 
 import { IonicVue } from '@ionic/vue';
@@ -26,54 +26,52 @@ import { localConfig } from './config/local';
 /* Theme variables */
 import './theme/variables.css';
 
-const app = createApp(App)
-  .use(IonicVue)
-  .use(router);
+const app = createApp(App).use(IonicVue).use(router);
 
+Sentry.init(
+  {
+    dsn: 'https://7f35532db4f8aca7c7b6992d488b39c1@o447951.ingest.sentry.io/4505912397660160',
+    integrations: [
+      SentryVue.vueIntegration({
+        tracingOptions: {
+          timeout: 1000,
+          trackComponents: true,
+          hooks: ['mount', 'update', 'unmount'],
+        },
+      }),
+      SentryVue.replayCanvasIntegration({
+        maskAllText: false,
+        blockAllMedia: false,
+      }),
+      ...(localConfig.spotlightSidecarUrl
+        ? [
+            Sentry.spotlightIntegration({
+              sidecarUrl: localConfig.spotlightSidecarUrl,
+            }),
+          ]
+        : []),
+    ],
+    tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
+    // Performance Monitoring
+    tracesSampleRate: 1.0, //  Capture 100% of the transactions
+    enableLogs: true,
+    beforeSendLog: log => {
+      return log;
+    },
 
-Sentry.init({
-  dsn: 'https://7f35532db4f8aca7c7b6992d488b39c1@o447951.ingest.sentry.io/4505912397660160',
-  integrations: [
-    SentryVue.vueIntegration({
-      tracingOptions: {
-        timeout: 1000,
-        trackComponents: true,
-        hooks: ["mount", "update", "unmount"]
-      }
-    }),
-    SentryVue.replayCanvasIntegration({
-      maskAllText: false,
-      blockAllMedia: false,
-    }),
-    ...(localConfig.spotlightSidecarUrl ? [Sentry.spotlightIntegration({
-      sidecarUrl: localConfig.spotlightSidecarUrl,
-    })] : []),
-  ],
-  tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
-  // Performance Monitoring
-  tracesSampleRate: 1.0, //  Capture 100% of the transactions
-  // Session Replay
-  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-  enableLogs: true,
-  beforeSendLog: (log) => {
-    return log;
-  },
-
-  siblingOptions: {
-    vueOptions: {
-      app: app,
-      attachErrorHandler: false,
-      attachProps: false,
+    siblingOptions: {
+      vueOptions: {
+        app: app,
+        attachErrorHandler: false,
+        attachProps: false,
+      },
     },
   },
-},
   // Forward the init method from @sentry/vue
   SentryVue.init,
 );
 
-
 router.isReady().then(() => {
   app.mount('#app');
-  app.mount('Hello')
+  app.mount('Hello');
 });

--- a/src/options.ts
+++ b/src/options.ts
@@ -129,7 +129,13 @@ export interface BaseCapacitorOptions {
  * Configuration options for the Sentry Capacitor SDK.
  */
 export interface CapacitorOptions
-  extends Omit<BrowserOptions, '_experiments' | 'enableMetrics'>,
+  extends Omit<
+      BrowserOptions,
+      | '_experiments'
+      | 'enableMetrics'
+      | 'replaysOnErrorSampleRate'
+      | 'replaysSessionSampleRate'
+    >,
     BaseCapacitorOptions {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -139,6 +145,9 @@ export interface CapacitorTransportOptions extends BrowserTransportOptions {}
 export interface CapacitorClientOptions
   extends Omit<
       ClientOptions<CapacitorTransportOptions>,
-      '_experiments' | 'enableMetrics'
+      | '_experiments'
+      | 'enableMetrics'
+      | 'replaysOnErrorSampleRate'
+      | 'replaysSessionSampleRate'
     >,
     BaseCapacitorOptions {}

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,24 +5,7 @@ import type { NuxtOptions, VueOptions } from './siblingOptions';
 // Direct reference of BrowserTransportOptions is not compatible with strict builds of latest versions of Typescript 5.
 type BrowserTransportOptions = Parameters<typeof makeFetchTransport>[0];
 
-type CapacitorBrowserClientReplayOptions = {
-  /**
-   * The sample rate for session-long replays.
-   * 1.0 will record all sessions and 0 will record none.
-   * @deprecated This option will be dropped on Capacitor V4.
-   */
-  replaysSessionSampleRate?: number;
-  /**
-   * The sample rate for sessions that has had an error occur.
-   * This is independent of `sessionSampleRate`.
-   * 1.0 will record all sessions and 0 will record none.
-   * @deprecated This option will be dropped on Capacitor V4.
-   */
-  replaysOnErrorSampleRate?: number;
-};
-
-export interface BaseCapacitorOptions
-  extends CapacitorBrowserClientReplayOptions {
+export interface BaseCapacitorOptions {
   /**
    * Enables crash reporting for native crashes.
    * Defaults to `true`.
@@ -146,13 +129,7 @@ export interface BaseCapacitorOptions
  * Configuration options for the Sentry Capacitor SDK.
  */
 export interface CapacitorOptions
-  extends Omit<
-      BrowserOptions,
-      | '_experiments'
-      | 'enableMetrics'
-      | 'replaysOnErrorSampleRate'
-      | 'replaysSessionSampleRate'
-    >,
+  extends Omit<BrowserOptions, '_experiments' | 'enableMetrics'>,
     BaseCapacitorOptions {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -162,9 +139,6 @@ export interface CapacitorTransportOptions extends BrowserTransportOptions {}
 export interface CapacitorClientOptions
   extends Omit<
       ClientOptions<CapacitorTransportOptions>,
-      | '_experiments'
-      | 'enableMetrics'
-      | 'replaysOnErrorSampleRate'
-      | 'replaysSessionSampleRate'
+      '_experiments' | 'enableMetrics'
     >,
     BaseCapacitorOptions {}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Release 3.2.1 added deprecations to Session Replay.
They are not needed on V4 so this PR rollsback the changes.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog