### PR TITLE
Ref(V4): Remove profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > [migration guide](https://docs.sentry.io/platforms/javascript/guides/capacitor/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Breaking Changes
+
+- Remove Profiling support ([#1217](https://github.com/getsentry/sentry-capacitor/pull/1217))
+
 ## 3.2.1
 
 ### Fixes

--- a/src/options.ts
+++ b/src/options.ts
@@ -168,6 +168,7 @@ export interface CapacitorClientOptions
       | '_experiments'
       | 'enableMetrics'
       | 'replaysOnErrorSampleRate'
+      | 'replaysSessionSampleRate'
       | 'profilesSampleRate'
       | 'profileLifecycle'
       | 'profileSessionSampleRate'

--- a/src/options.ts
+++ b/src/options.ts
@@ -152,6 +152,9 @@ export interface CapacitorOptions
       | 'enableMetrics'
       | 'replaysOnErrorSampleRate'
       | 'replaysSessionSampleRate'
+      | 'profilesSampleRate'
+      | 'profileLifecycle'
+      | 'profileSessionSampleRate'
     >,
     BaseCapacitorOptions {}
 
@@ -165,6 +168,8 @@ export interface CapacitorClientOptions
       | '_experiments'
       | 'enableMetrics'
       | 'replaysOnErrorSampleRate'
-      | 'replaysSessionSampleRate'
+      | 'profilesSampleRate'
+      | 'profileLifecycle'
+      | 'profileSessionSampleRate'
     >,
     BaseCapacitorOptions {}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Related to https://github.com/getsentry/sentry-capacitor/issues/1199

We will drop support for Profiling on Capacitor.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



## :green_heart: How did you test it?

Locally on build time

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
