### PR TITLE
feat(deps): bump Android SDK from 8.35.0 to 8.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Dependencies
 
-- Bump Android SDK from v8.35.0 to v8.41.0 ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+- Bump Android SDK from v8.35.0 to v8.41.0 ([#1247](https://github.com/getsentry/sentry-capacitor/pull/1247))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8410)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.35.0...8.41.0)
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Dependencies
 
+- Bump Android SDK from v8.35.0 to v8.41.0 ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8410)
+  - [diff](https://github.com/getsentry/sentry-java/compare/8.35.0...8.41.0)
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,5 +91,5 @@ repositories {
 
 dependencies {
     implementation project(':capacitor-android')
-    implementation 'io.sentry:sentry-android:8.35.0'
+    implementation 'io.sentry:sentry-android:8.41.0'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Bumps the Sentry Android SDK dependency from `8.35.0` to `8.41.0`.

## :bulb: Motivation and Context
Keeps the Android SDK up to date with the latest upstream releases, picking up bug fixes and improvements from versions 8.36.0 through 8.41.0.

- [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8410)
- [diff](https://github.com/getsentry/sentry-java/compare/8.35.0...8.41.0)

## :green_heart: How did you test it?

On Sample apps.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps