### PR TITLE
feat(deps): bump Sentry Cocoa SDK from 9.8.0 to 9.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)
+- Bump Cocoa SDK from v9.8.0 to v9.13.0 ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9130)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.13.0)
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)
-- Bump Cocoa SDK from v9.8.0 to v9.13.0 ([#???](https://github.com/getsentry/sentry-capacitor/pull/???))
+- Bump Cocoa SDK from v9.8.0 to v9.13.0 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9130)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.13.0)
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", "7.0.0"..<"9.0.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.8.0")
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.13.0")
     ],
     targets: [
         .target(

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
 
-  s.dependency 'Sentry', '9.8.0'
+  s.dependency 'Sentry', '9.13.0'
   s.dependency 'Capacitor'
 
   if File.exist?('../../@capacitor/core/package.json') == false

--- a/example/ionic-angular-v7/ios/App/Podfile.lock
+++ b/example/ionic-angular-v7/ios/App/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorCordova (7.0.1)
-  - Sentry (9.8.0):
-    - Sentry/Core (= 9.8.0)
-  - Sentry/Core (9.8.0)
-  - "SentryCapacitor (3.1.0+6503a2cd)":
+  - Sentry (9.13.0):
+    - Sentry/Core (= 9.13.0)
+  - Sentry/Core (9.13.0)
+  - "SentryCapacitor (4.0.0+690e9f79)":
     - Capacitor
-    - Sentry (= 9.8.0)
+    - Sentry (= 9.13.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -29,8 +29,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: de199cba6c8b20995428ad0b7cb0bc6ca625ffd4
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  Sentry: 88746bf877eff714bc45315a39ad1d1efea2cdda
-  SentryCapacitor: 66d8b9cf3f785e22dadd0d05b1c6f0fbbe3951ed
+  Sentry: 5c3f67235d4c16fcfab43158a8c1502a18fece9a
+  SentryCapacitor: b61b47c846aa2418e44f4ddc8e538348f3007dce
 
 PODFILE CHECKSUM: 1556569b6b66479d0ac544257ad54061032afdfc
 

--- a/example/ionic-vue3/ios/App/Podfile.lock
+++ b/example/ionic-vue3/ios/App/Podfile.lock
@@ -10,12 +10,12 @@ PODS:
     - Capacitor
   - CapacitorStatusBar (8.0.0):
     - Capacitor
-  - Sentry (9.8.0):
-    - Sentry/Core (= 9.8.0)
-  - Sentry/Core (9.8.0)
-  - "SentryCapacitor (3.1.0+6503a2cd)":
+  - Sentry (9.13.0):
+    - Sentry/Core (= 9.13.0)
+  - Sentry/Core (9.13.0)
+  - "SentryCapacitor (4.0.0+690e9f79)":
     - Capacitor
-    - Sentry (= 9.8.0)
+    - Sentry (= 9.13.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -53,8 +53,8 @@ SPEC CHECKSUMS:
   CapacitorHaptics: 2079d9fa04c5a71e18663b4722323c304c58245c
   CapacitorKeyboard: d7868c079a4d5277a3deca27a10a488fcbbb8b69
   CapacitorStatusBar: 312e2e67928dfe9514c4a8916a1fd610552f5f35
-  Sentry: 88746bf877eff714bc45315a39ad1d1efea2cdda
-  SentryCapacitor: 66d8b9cf3f785e22dadd0d05b1c6f0fbbe3951ed
+  Sentry: 5c3f67235d4c16fcfab43158a8c1502a18fece9a
+  SentryCapacitor: b61b47c846aa2418e44f4ddc8e538348f3007dce
 
 PODFILE CHECKSUM: 72b7933f33f449ffc285e956394345ca4767d300
 


### PR DESCRIPTION

  ## :loudspeaker: Type of change
  - [ ] Bugfix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactoring


  ## :scroll: Description
  Bumps the Sentry Cocoa SDK dependency from `9.8.0` to `9.13.0` in `Package.swift` and `SentryCapacitor.podspec`, and updates the corresponding `Podfile.lock` files in the sample apps.


  ## :bulb: Motivation and Context
  Keeps the iOS/macOS native layer up-to-date with the latest Sentry Cocoa releases, picking up bug fixes and improvements shipped between 9.8.0 and 9.13.0.

  - [Cocoa SDK changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9130)
  - [Diff 9.8.0 → 9.13.0](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.13.0)


  ## :green_heart: How did you test it?
  - Verified `Package.swift` and `SentryCapacitor.podspec` resolve to the correct version.
  - `Podfile.lock` updated for `example/ionic-angular-v7` and `example/ionic-vue3` sample apps.
  - tested locally on a sample app.

  ## :pencil: Checklist
  - [ ] I added tests to verify changes
  - [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
  - [x] I updated the docs if needed.
  - [ ] I updated the wizard if needed.
  - [ ] All tests passing
  - [x] No breaking changes

  ## :crystal_ball: Next steps