### PR TITLE
bump(sentry-cocoa): Bump Sentry Cocoa to 9.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
       },
     });
     ```
+
 - Add `strictTraceContinuation` and `orgId` options for trace continuation validation ([#1166](https://github.com/getsentry/sentry-capacitor/pull/1166))
 
 ### Dependencies
@@ -40,9 +41,9 @@
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)
-- Bump Cocoa SDK from v9.8.0 to v9.13.0 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9130)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.13.0)
+- Bump Cocoa SDK from v9.8.0 to v9.16.0 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9160)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.16.0)
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)
-- Bump Cocoa SDK from v9.8.0 to v9.16.0 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248), [#1276](https://github.com/getsentry/sentry-capacitor/pull/1276))
+- Bump Cocoa SDK from v9.8.0 to v9.16.1 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248), [#1276](https://github.com/getsentry/sentry-capacitor/pull/1276))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9160)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.16.0)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.16.1)
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@
       },
     });
     ```
-
 - Add `strictTraceContinuation` and `orgId` options for trace continuation validation ([#1166](https://github.com/getsentry/sentry-capacitor/pull/1166))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)
 - Bump Cocoa SDK from v9.8.0 to v9.16.1 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248), [#1276](https://github.com/getsentry/sentry-capacitor/pull/1276))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9160)
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9161)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.16.1)
 
 ## 4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Bump JavaScript Sibling SDKs from v9.42.0 to v10.52.0 ([#1244](https://github.com/getsentry/sentry-capacitor/pull/1244))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.52.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.42.0...10.52.0)
-- Bump Cocoa SDK from v9.8.0 to v9.16.0 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248))
+- Bump Cocoa SDK from v9.8.0 to v9.16.0 ([#1248](https://github.com/getsentry/sentry-capacitor/pull/1248), [#1276](https://github.com/getsentry/sentry-capacitor/pull/1276))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9160)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.16.0)
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", "7.0.0"..<"9.0.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.13.0")
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.16.1")
     ],
     targets: [
         .target(

--- a/SentryCapacitor.podspec
+++ b/SentryCapacitor.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
 
-  s.dependency 'Sentry', '9.13.0'
+  s.dependency 'Sentry', '9.16.1'
   s.dependency 'Capacitor'
 
   if File.exist?('../../@capacitor/core/package.json') == false


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

   Bumps the Sentry Cocoa SDK from `9.8.0` to `9.16.1`.

   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9161)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.8.0...9.16.1)
   
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

   Keeps the iOS native SDK up to date with the latest Sentry Cocoa release, picking up bug fixes and improvements shipped across 9.9.x–9.16.x.

## :green_heart: How did you test it?

   Verified example apps resolve and build with the new Cocoa version via updated `Podfile.lock` and `Package.resolved` files.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
