### PR TITLE
fix(scripts): match podspec dependency name in update-cocoa.sh

### DIFF
--- a/scripts/update-cocoa.sh
+++ b/scripts/update-cocoa.sh
@@ -8,7 +8,7 @@ case $1 in
 get-version)
     if [[ -f "$podFile" ]]; then
         podContent=$(cat $podFile)
-        podRegex="('Sentry/HybridSDK', *)'([0-9\.]+)'"
+        podRegex="('Sentry', *)'([0-9\.]+)'"
         if [[ $podContent =~ $podRegex ]]; then
             echo ${BASH_REMATCH[2]}
             exit 0
@@ -24,7 +24,7 @@ set-version)
     # Update podspec file
     if [[ -f "$podFile" ]]; then
         podContent=$(cat $podFile)
-        podRegex="('Sentry/HybridSDK', *)'([0-9\.]+)'"
+        podRegex="('Sentry', *)'([0-9\.]+)'"
         if [[ $podContent =~ $podRegex ]]; then
             newValue="${BASH_REMATCH[1]}'$2'"
             echo "${podContent/${BASH_REMATCH[0]}/$newValue}" >$podFile


### PR DESCRIPTION
## Summary
- The Cocoa SDK auto-bump workflow was failing with "Failed to find sentry-cocoa version in either ... SentryCapacitor.podspec".
- PR #1106 renamed the podspec dependency from `'Sentry/HybridSDK'` to `'Sentry'`, but `scripts/update-cocoa.sh`'s regex was never updated to match, silently breaking `get-version`/`set-version` for the auto-updater.
- Updated the regex in both `get-version` and `set-version` to match `'Sentry'`.

## Test plan
- [x] `./scripts/update-cocoa.sh get-version` now returns `9.16.1` (matches `SentryCapacitor.podspec`)