### PR TITLE
fix(scripts): allow caret-prefixed version in update-package-json get-version

### DIFF
--- a/scripts/update-package-json.sh
+++ b/scripts/update-package-json.sh
@@ -6,7 +6,7 @@ updatePeerPackages=${updatePeerPackages:-0}
 
 case $1 in
 get-version)
-    regex='"'${packages[0]}'": *"([0-9.]+)"'
+    regex='"'${packages[0]}'": *"\^?([0-9.]+)"'
     if ! [[ $content =~ $regex ]]; then
         echo "Failed to find plugin '${packages[0]}' version in $file"
         exit 1


### PR DESCRIPTION
## Summary
- The Wizard dependency updater workflow was failing with `Failed to find plugin '@sentry/wizard' version in package.json`.
- `@sentry/wizard` is pinned with a caret range (`^6.12.0`), but the `get-version` regex in `scripts/update-package-json.sh` only matched exact versions (`"([0-9.]+)"`), not `"^6.12.0"`.
- Updated the regex to allow an optional `^` prefix, while remaining backwards compatible with packages pinned without a range prefix (e.g. `@sentry/browser`).

## Test plan
- [x] Verified the updated regex matches `"@sentry/wizard": "^6.12.0"` and extracts `6.12.0`
- [x] Verified the updated regex still matches `"@sentry/browser": "10.52.0"` and extracts `10.52.0`