### PR TITLE
docs: Add AI Use section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,3 +182,8 @@ dependencies {
 ## Bumping Capacitor
 
 When bumping the dependency of Capacitor, always have a look on the following link to see any changes required on the SDK in order to support the latest versions of Capacitor: https://capacitorjs.com/docs/updating/plugins/6-0
+
+
+## AI Use
+
+You are welcome to use whatever tools you prefer for making a contribution. However, any changes you propose have to be reviewed and tested by you, a human, first, before you submit a pull request with them for the Sentry team to review. If we feel like that did not happen, we will close the PR outright. For example, we will not review visibly AI-generated PRs from an agent instructed to look for and "fix" open issues in the repo. This aligns with our SDK principle: [every line has an owner](https://develop.sentry.dev/sdk/getting-started/principles/#every-line-has-an-owner).


### PR DESCRIPTION
Adds the `## AI Use` section from [sentry-cocoa's CONTRIBUTING.md](https://github.com/getsentry/sentry-cocoa/blob/main/CONTRIBUTING.md#ai-use) to align all SDK repos on the same AI contribution policy.

The section clarifies that contributors are welcome to use AI tools, but all proposed changes must be reviewed and tested by a human before submitting a PR, consistent with the SDK principle [every line has an owner](https://develop.sentry.dev/sdk/getting-started/principles/#every-line-has-an-owner).