### PR TITLE
fix(ios): honor enableAppHangTracking, appHangTimeoutInterval and enableWatchdogTerminationTracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > [migration guide](https://docs.sentry.io/platforms/javascript/guides/capacitor/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- iOS: `enableAppHangTracking`, `appHangTimeoutInterval` and `enableWatchdogTerminationTracking` are now correctly passed into Sentry Cocoa SDK ([#1326](https://github.com/getsentry/sentry-capacitor/issues/1326))
+
 ## 4.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- iOS: `enableAppHangTracking`, `appHangTimeoutInterval` and `enableWatchdogTerminationTracking` are now correctly passed into Sentry Cocoa SDK ([#1326](https://github.com/getsentry/sentry-capacitor/issues/1326))
+- iOS: `enableAppHangTracking`, `appHangTimeoutInterval` and `enableWatchdogTerminationTracking` are now correctly passed into Sentry Cocoa SDK ([#1350](https://github.com/getsentry/sentry-capacitor/pull/1350))
 
 ## 4.2.0
 

--- a/ios/Sources/SentryCapacitorPlugin/SentryCapacitorPlugin.swift
+++ b/ios/Sources/SentryCapacitorPlugin/SentryCapacitorPlugin.swift
@@ -165,6 +165,19 @@ public class SentryCapacitorPlugin: CAPPlugin, CAPBridgedPlugin {
         if let strictTraceContinuation = dict["strictTraceContinuation"] as? Bool {
             options.strictTraceContinuation = strictTraceContinuation
         }
+
+        if let enableAppHangTracking = dict["enableAppHangTracking"] as? Bool {
+            options.enableAppHangTracking = enableAppHangTracking
+        }
+
+        if let appHangTimeoutInterval = dict["appHangTimeoutInterval"] as? Double {
+            options.appHangTimeoutInterval = appHangTimeoutInterval
+        }
+
+        if let enableWatchdogTerminationTracking = dict["enableWatchdogTerminationTracking"] as? Bool {
+            options.enableWatchdogTerminationTracking = enableWatchdogTerminationTracking
+        }
+
         if let orgId = dict["orgId"] {
             if let orgIdString = orgId as? String {
                 options.orgId = orgIdString

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -87,7 +87,7 @@ describe('client', () => {
       expect(NATIVE.initNativeSdk).toHaveBeenCalledWith(nativeOptions);
       expect(mockOriginalInit).toHaveBeenCalledWith(browserOptions);
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Native Sentry SDK failed to initialize. Using Sentry JavaScript SDK without native integraiton.\n',
+        'Native Sentry SDK failed to initialize. Using Sentry JavaScript SDK without native integration.\n',
         { error: initError }
       );
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
`createOptions(from:)` in `ios/Sources/SentryCapacitorPlugin/SentryCapacitorPlugin.swift` only mapped an explicit allowlist of keys onto the native `Options` object. `enableAppHangTracking`, `appHangTimeoutInterval`, and `enableWatchdogTerminationTracking` were not in that allowlist, so they were silently dropped even though the JS layer's `FilterNativeOptions()` already forwarded them on iOS. This PR adds the three missing keys to `createOptions(from:)` so they are applied to the native `Options` object before `SentrySDK.start(options:)` is called.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Passing `enableAppHangTracking: false` or a custom `appHangTimeoutInterval` to `Sentry.init()` had no effect on iOS: sentry-cocoa always started with its defaults (App Hang tracking enabled, 2s timeout), with no warning. `enableWatchdogTerminationTracking` was affected the same way.

Fixes #1326

## :green_heart: How did you test it?
Manual code review against sentry-cocoa 9.16.1's `Options.swift` (the version pinned in `SentryCapacitor.podspec`) to confirm the property names/types (`enableAppHangTracking: Bool`, `appHangTimeoutInterval: TimeInterval`, `enableWatchdogTerminationTracking: Bool`) match, and by mirroring the existing pattern used for every other option in `createOptions(from:)`. I did not have Xcode available to run a full native build/test on this machine.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Would be good to add a unit test around `SentryCapacitorPlugin.createOptions(from:)` (currently untested) to lock this in and cover future option additions.
