### PR TITLE
chore: warn about upcoming CocoaPods deprecation for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Deprecations
 
-- iOS: CocoaPods support is deprecated, the podspec setup will be removed in the next minor version (#TODO: add PR link when opened)
+- iOS: CocoaPods support is deprecated, the podspec setup will be removed in the next minor version ([#1353](https://github.com/getsentry/sentry-capacitor/pull/1353))
   - `sentry-cocoa` has [deprecated CocoaPods](https://github.com/getsentry/sentry-cocoa/pull/7526) and stopped publishing new releases to CocoaPods trunk after `9.19.1`, so `SentryCapacitor.podspec` can no longer be kept up to date.
   - Please migrate to Swift Package Manager (`Package.swift`) before upgrading to the next minor version. The removal itself is already staged in [#1352](https://github.com/getsentry/sentry-capacitor/pull/1352).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ## Unreleased
 
+### Deprecations
+
+- iOS: CocoaPods support is deprecated, the podspec setup will be removed in the next minor version (#TODO: add PR link when opened)
+  - `sentry-cocoa` has [deprecated CocoaPods](https://github.com/getsentry/sentry-cocoa/pull/7526) and stopped publishing new releases to CocoaPods trunk after `9.19.1`, so `SentryCapacitor.podspec` can no longer be kept up to date.
+  - Please migrate to Swift Package Manager (`Package.swift`) before upgrading to the next minor version. The removal itself is already staged in [#1352](https://github.com/getsentry/sentry-capacitor/pull/1352).
+
 ### Fixes
 
 - iOS: `enableAppHangTracking`, `appHangTimeoutInterval` and `enableWatchdogTerminationTracking` are now correctly passed into Sentry Cocoa SDK ([#1350](https://github.com/getsentry/sentry-capacitor/pull/1350))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ### Deprecations
 
-- iOS: CocoaPods support is deprecated, the podspec setup will be removed in the next minor version ([#1353](https://github.com/getsentry/sentry-capacitor/pull/1353))
+- iOS: CocoaPods support is deprecated, the podspec setup will be removed in the next minor version.
   - `sentry-cocoa` has [deprecated CocoaPods](https://github.com/getsentry/sentry-cocoa/pull/7526) and stopped publishing new releases to CocoaPods trunk after `9.19.1`, so `SentryCapacitor.podspec` can no longer be kept up to date.
-  - Please migrate to Swift Package Manager (`Package.swift`) before upgrading to the next minor version. The removal itself is already staged in [#1352](https://github.com/getsentry/sentry-capacitor/pull/1352).
+  - Please migrate to Swift Package Manager (`Package.swift`) before upgrading to the next minor version.
 
 ### Fixes
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Add a `### Deprecations` entry to the changelog warning that iOS CocoaPods support is deprecated, ahead of the actual removal.

## :bulb: Motivation and Context
`sentry-cocoa` [deprecated CocoaPods](https://github.com/getsentry/sentry-cocoa/pull/7526) and stopped publishing new releases to CocoaPods trunk after `9.19.1`, so `SentryCapacitor.podspec` can't be kept up to date. The actual removal is already staged in #1352; this PR gives CocoaPods users advance notice and points them at SPM before that lands, instead of the podspec just disappearing with no warning.

## :green_heart: How did you test it?
Docs-only change (CHANGELOG.md), no code affected.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps
- Ships in the next minor release; the actual podspec removal (#1352) is targeted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTc7FjqtGsy2MFcvfBftJ4