### PR TITLE
build: Bump Sentry JavaScript SDK from 10.60.0 to 10.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Dependencies
 
-- Bump JavaScript SDK from v10.60.0 to v10.69.0
+- Bump JavaScript SDK from v10.60.0 to v10.69.0 ([#1354](https://github.com/getsentry/sentry-capacitor/pull/1354))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.69.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/10.60.0...10.69.0)
 - Bump Android SDK from v8.41.0 to v8.50.1 ([#1344](https://github.com/getsentry/sentry-capacitor/pull/1344))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Dependencies
 
+- Bump JavaScript SDK from v10.60.0 to v10.69.0
+  - [changelog](https://github.com/getsentry/sentry-javascript/blob/10.69.0/CHANGELOG.md)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/10.60.0...10.69.0)
 - Bump Android SDK from v8.41.0 to v8.50.1 ([#1344](https://github.com/getsentry/sentry-capacitor/pull/1344))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8501)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.41.0...8.50.1)

--- a/example/ionic-angular-v7/ios/App/CapApp-SPM/Package.swift
+++ b/example/ionic-angular-v7/ios/App/CapApp-SPM/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "7.0.1"),
-        .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "7.6.7"),
+        .package(name: "SentryCapacitor", path: "../../../.yalc/@sentry/capacitor")
     ],
     targets: [
         .target(

--- a/example/ionic-angular-v7/package.json
+++ b/example/ionic-angular-v7/package.json
@@ -13,7 +13,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^8.0.0",
-    "@sentry/angular": "10.60.0",
+    "@sentry/angular": "10.69.0",
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
     "rxjs": "~7.8.0",
     "tslib": "^2.0.0",

--- a/example/ionic-angular-v7/yarn.lock
+++ b/example/ionic-angular-v7/yarn.lock
@@ -4107,56 +4107,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/angular@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/angular@npm:10.60.0"
+"@sentry/angular@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/angular@npm:10.69.0"
   dependencies:
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
     tslib: "npm:^2.4.1"
   peerDependencies:
     "@angular/common": ">= 14.x <= 22.x"
     "@angular/core": ">= 14.x <= 22.x"
     "@angular/router": ">= 14.x <= 22.x"
     rxjs: ^6.5.5 || ^7.x
-  checksum: 10c0/ecf544581651955dfa7d9322ebb7c668554553729da25df8039189fe5a3935cc09b824a3f77b75fad834cc107f0f5e2467cda073dce4ed6ad346a1e424c36673
+  checksum: 10c0/b476e5c9de120fc73586e4d41e3f6dcb44593d74936cca733ebca25adfe15467d0951bcb6cd835dc33f962bd472e0806f78991447289e0c7f72c4bf30deaa3f9
   languageName: node
   linkType: hard
 
-"@sentry/browser-utils@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser-utils@npm:10.60.0"
+"@sentry/browser-utils@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser-utils@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/a8da259fca9513143c7eb2946a6c1cefbf3e844b57978ebf8f1fd52515ee10ec0a9237f73ccaad69e684ffabc60805014a13eb895c6f477cfa2417cdebf479f7
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/2b4a1429e39e48ba4729f30fae4dd217a42203c69e114fcbe3633b5690ca1ea65658b25e7e2a03c5b2df7b62362930e9d1ac648b0653f89058fd1c4f56df55df
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser@npm:10.60.0"
+"@sentry/browser@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/feedback": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-    "@sentry/replay-canvas": "npm:10.60.0"
-  checksum: 10c0/63ff8d70a2fe365ee3fa859c54715defcf08bb5ae8a56fb153826f2a4088d6307b3fa1c19e3d0cfd4d8145cdd1addd71c4157515c5c13251d93a45c4d59ff9b1
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/feedback": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+    "@sentry/replay-canvas": "npm:10.69.0"
+  checksum: 10c0/0a0c2cdf0801b92bb274f74cba9b0d3cc660f2b3fd85937c3b6e9eb9021799dc8bf015b72ac3ece29a63c437a2dbe7dc13d559220f81742b8212ec2b56a89912
   languageName: node
   linkType: hard
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor::locator=ionic-angular%40workspace%3A.":
-  version: 4.1.0+2f79fdca
-  resolution: "@sentry/capacitor@file:.yalc/@sentry/capacitor#.yalc/@sentry/capacitor::hash=816988&locator=ionic-angular%40workspace%3A."
+  version: 4.2.0+c5265af2
+  resolution: "@sentry/capacitor@file:.yalc/@sentry/capacitor#.yalc/@sentry/capacitor::hash=9385cf&locator=ionic-angular%40workspace%3A."
   dependencies:
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/types": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/types": "npm:10.69.0"
   peerDependencies:
     "@capacitor/core": ">=3.0.0"
-    "@sentry/angular": 10.60.0
-    "@sentry/react": 10.60.0
-    "@sentry/vue": 10.60.0
+    "@sentry/angular": 10.69.0
+    "@sentry/react": 10.69.0
+    "@sentry/vue": 10.69.0
   peerDependenciesMeta:
     "@sentry/angular":
       optional: true
@@ -4164,7 +4167,7 @@ __metadata:
       optional: true
     "@sentry/vue":
       optional: true
-  checksum: 10c0/e5f9be2a5206dd3cc5304fa1f8d05fe1709c8c0c39f8a0ac4601adf1b0f51468488a39e662de8c16e8b773e5f8e1c6ebf61e5edabaec6d48d029bad4788682b8
+  checksum: 10c0/88f200d15caad270881a28141e6b238e02b2ed0165def75440c0b74cabbf31b80ffccff216d446bcf3d2f3d15afa8004382b7147350c2f49f6ac74f9a7c6d179
   languageName: node
   linkType: hard
 
@@ -4264,48 +4267,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/core@npm:10.60.0"
-  checksum: 10c0/7b34d28e35258aafba1302cfaffa1e147dfc11cf813ad88c6faeb29059d47bb66ad59c38cbd569f9e281c3c4fa46ff99d2a602ab0b100db67186e276997bbae2
+"@sentry/conventions@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@sentry/conventions@npm:0.16.0"
+  checksum: 10c0/415aaa94cade2b8e0dd00ad9aa06d998d7fe95658a8f43b6e4ef382e3b4c115c8f199ca0fe9b74a98500e8270dc68d5333fd943f7dad6ed78f60d9372231fbe8
   languageName: node
   linkType: hard
 
-"@sentry/feedback@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/feedback@npm:10.60.0"
+"@sentry/core@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/core@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/46880a893dd64ff9758e492851683606c0bc575ba1829a031983e919a30d7c72cf5cc3fd80ee4884f80a114df61cb976a0625013f5d8f04bdff0ba4bd94bb48f
+    "@sentry/conventions": "npm:^0.16.0"
+  checksum: 10c0/d6a00824a12d332063ed309c3fc263715ac1d20d253ddfce75d22b8b046da4eb2f99d843628bf365281ca625826bc6a9bdf5dec0ce24c9eb88712f7187858891
   languageName: node
   linkType: hard
 
-"@sentry/replay-canvas@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay-canvas@npm:10.60.0"
+"@sentry/feedback@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/feedback@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-  checksum: 10c0/d531cfb682f68bb5bb236ccc84a8a80eb1163dcba0c69629b7115ff03dffc8a23d2c50e41c749925fe0ca2e6fe91931529fb41f5de0c85f2722a90e3287a77d2
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/397c463bf47054c7210355eeebb81048f21f5b6d8af5e835e514eebebf670e49aa4fc07c73cbf0327a5ed88fd250a131a8045c024f164dac7587c02eb3cd0be7
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay@npm:10.60.0"
+"@sentry/replay-canvas@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay-canvas@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/b8c6199153ea4d5949f83f38c797aba7a3037d1edcd6874210b0d0e6ee269b9bbfa6275b0af9dd100e872db847902b610cd6fe914458a032de9aff95bf23c757
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+  checksum: 10c0/25f42d13a534c5608cc0c01624068c5f08e3157c309e53cf5a5788fa89ec66bcf706c649ff4d94240b879e8a62036813acd4416a3072eea88cd98663bfe91fb7
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/types@npm:10.60.0"
+"@sentry/replay@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/ab61ca95336b21530242e89f6cc252c8ae65d43473b8ed73dea0cd951f938cea586685ed75127dde075ebcdc0c5388a86b360c9eb6f6bcd299ed6c1bcb67e6bf
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/3c3918a037b9c1f8dc1d06b0cc456338d2316b10cef6ad42cc9154534631f48f47c4398fc503ad1d814326c489a075742e676abf27a61b3443c71265dcdadf30
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/types@npm:10.69.0"
+  dependencies:
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/be2c617dd2fd9a5d9f9a2eae004581028460b2857fe5dd0e0016313853e5a4b7a36f9361f477e2984c9bb0d4a30ff38e46b709ae671cff74ad89f5d82530eb17
   languageName: node
   linkType: hard
 
@@ -7767,7 +7779,7 @@ __metadata:
     "@ionic/angular": "npm:^8.0.0"
     "@ionic/angular-toolkit": "npm:^10.0.0"
     "@ionic/cli": "npm:^7.2.1"
-    "@sentry/angular": "npm:10.60.0"
+    "@sentry/angular": "npm:10.69.0"
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor"
     "@sentry/cli": "npm:^2.58.6"
     "@types/jasmine": "npm:~5.1.0"

--- a/example/ionic-angular-v8/ios/App/CapApp-SPM/Package.swift
+++ b/example/ionic-angular-v8/ios/App/CapApp-SPM/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.0.0"),
-        .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
+        .package(name: "SentryCapacitor", path: "../../../.yalc/@sentry/capacitor")
     ],
     targets: [
         .target(

--- a/example/ionic-angular-v8/package.json
+++ b/example/ionic-angular-v8/package.json
@@ -13,7 +13,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^8.0.0",
-    "@sentry/angular": "10.60.0",
+    "@sentry/angular": "10.69.0",
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
     "rxjs": "~7.8.0",
     "tslib": "^2.0.0",

--- a/example/ionic-angular-v8/yarn.lock
+++ b/example/ionic-angular-v8/yarn.lock
@@ -4168,56 +4168,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/angular@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/angular@npm:10.60.0"
+"@sentry/angular@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/angular@npm:10.69.0"
   dependencies:
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
     tslib: "npm:^2.4.1"
   peerDependencies:
     "@angular/common": ">= 14.x <= 22.x"
     "@angular/core": ">= 14.x <= 22.x"
     "@angular/router": ">= 14.x <= 22.x"
     rxjs: ^6.5.5 || ^7.x
-  checksum: 10c0/ecf544581651955dfa7d9322ebb7c668554553729da25df8039189fe5a3935cc09b824a3f77b75fad834cc107f0f5e2467cda073dce4ed6ad346a1e424c36673
+  checksum: 10c0/b476e5c9de120fc73586e4d41e3f6dcb44593d74936cca733ebca25adfe15467d0951bcb6cd835dc33f962bd472e0806f78991447289e0c7f72c4bf30deaa3f9
   languageName: node
   linkType: hard
 
-"@sentry/browser-utils@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser-utils@npm:10.60.0"
+"@sentry/browser-utils@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser-utils@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/a8da259fca9513143c7eb2946a6c1cefbf3e844b57978ebf8f1fd52515ee10ec0a9237f73ccaad69e684ffabc60805014a13eb895c6f477cfa2417cdebf479f7
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/2b4a1429e39e48ba4729f30fae4dd217a42203c69e114fcbe3633b5690ca1ea65658b25e7e2a03c5b2df7b62362930e9d1ac648b0653f89058fd1c4f56df55df
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser@npm:10.60.0"
+"@sentry/browser@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/feedback": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-    "@sentry/replay-canvas": "npm:10.60.0"
-  checksum: 10c0/63ff8d70a2fe365ee3fa859c54715defcf08bb5ae8a56fb153826f2a4088d6307b3fa1c19e3d0cfd4d8145cdd1addd71c4157515c5c13251d93a45c4d59ff9b1
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/feedback": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+    "@sentry/replay-canvas": "npm:10.69.0"
+  checksum: 10c0/0a0c2cdf0801b92bb274f74cba9b0d3cc660f2b3fd85937c3b6e9eb9021799dc8bf015b72ac3ece29a63c437a2dbe7dc13d559220f81742b8212ec2b56a89912
   languageName: node
   linkType: hard
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor::locator=ionic-angular%40workspace%3A.":
-  version: 4.1.0+2f79fdca
-  resolution: "@sentry/capacitor@file:.yalc/@sentry/capacitor#.yalc/@sentry/capacitor::hash=816988&locator=ionic-angular%40workspace%3A."
+  version: 4.2.0+c5265af2
+  resolution: "@sentry/capacitor@file:.yalc/@sentry/capacitor#.yalc/@sentry/capacitor::hash=9385cf&locator=ionic-angular%40workspace%3A."
   dependencies:
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/types": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/types": "npm:10.69.0"
   peerDependencies:
     "@capacitor/core": ">=3.0.0"
-    "@sentry/angular": 10.60.0
-    "@sentry/react": 10.60.0
-    "@sentry/vue": 10.60.0
+    "@sentry/angular": 10.69.0
+    "@sentry/react": 10.69.0
+    "@sentry/vue": 10.69.0
   peerDependenciesMeta:
     "@sentry/angular":
       optional: true
@@ -4225,7 +4228,7 @@ __metadata:
       optional: true
     "@sentry/vue":
       optional: true
-  checksum: 10c0/e5f9be2a5206dd3cc5304fa1f8d05fe1709c8c0c39f8a0ac4601adf1b0f51468488a39e662de8c16e8b773e5f8e1c6ebf61e5edabaec6d48d029bad4788682b8
+  checksum: 10c0/88f200d15caad270881a28141e6b238e02b2ed0165def75440c0b74cabbf31b80ffccff216d446bcf3d2f3d15afa8004382b7147350c2f49f6ac74f9a7c6d179
   languageName: node
   linkType: hard
 
@@ -4325,48 +4328,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/core@npm:10.60.0"
-  checksum: 10c0/7b34d28e35258aafba1302cfaffa1e147dfc11cf813ad88c6faeb29059d47bb66ad59c38cbd569f9e281c3c4fa46ff99d2a602ab0b100db67186e276997bbae2
+"@sentry/conventions@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@sentry/conventions@npm:0.16.0"
+  checksum: 10c0/415aaa94cade2b8e0dd00ad9aa06d998d7fe95658a8f43b6e4ef382e3b4c115c8f199ca0fe9b74a98500e8270dc68d5333fd943f7dad6ed78f60d9372231fbe8
   languageName: node
   linkType: hard
 
-"@sentry/feedback@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/feedback@npm:10.60.0"
+"@sentry/core@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/core@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/46880a893dd64ff9758e492851683606c0bc575ba1829a031983e919a30d7c72cf5cc3fd80ee4884f80a114df61cb976a0625013f5d8f04bdff0ba4bd94bb48f
+    "@sentry/conventions": "npm:^0.16.0"
+  checksum: 10c0/d6a00824a12d332063ed309c3fc263715ac1d20d253ddfce75d22b8b046da4eb2f99d843628bf365281ca625826bc6a9bdf5dec0ce24c9eb88712f7187858891
   languageName: node
   linkType: hard
 
-"@sentry/replay-canvas@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay-canvas@npm:10.60.0"
+"@sentry/feedback@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/feedback@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-  checksum: 10c0/d531cfb682f68bb5bb236ccc84a8a80eb1163dcba0c69629b7115ff03dffc8a23d2c50e41c749925fe0ca2e6fe91931529fb41f5de0c85f2722a90e3287a77d2
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/397c463bf47054c7210355eeebb81048f21f5b6d8af5e835e514eebebf670e49aa4fc07c73cbf0327a5ed88fd250a131a8045c024f164dac7587c02eb3cd0be7
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay@npm:10.60.0"
+"@sentry/replay-canvas@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay-canvas@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/b8c6199153ea4d5949f83f38c797aba7a3037d1edcd6874210b0d0e6ee269b9bbfa6275b0af9dd100e872db847902b610cd6fe914458a032de9aff95bf23c757
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+  checksum: 10c0/25f42d13a534c5608cc0c01624068c5f08e3157c309e53cf5a5788fa89ec66bcf706c649ff4d94240b879e8a62036813acd4416a3072eea88cd98663bfe91fb7
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/types@npm:10.60.0"
+"@sentry/replay@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/ab61ca95336b21530242e89f6cc252c8ae65d43473b8ed73dea0cd951f938cea586685ed75127dde075ebcdc0c5388a86b360c9eb6f6bcd299ed6c1bcb67e6bf
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/3c3918a037b9c1f8dc1d06b0cc456338d2316b10cef6ad42cc9154534631f48f47c4398fc503ad1d814326c489a075742e676abf27a61b3443c71265dcdadf30
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/types@npm:10.69.0"
+  dependencies:
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/be2c617dd2fd9a5d9f9a2eae004581028460b2857fe5dd0e0016313853e5a4b7a36f9361f477e2984c9bb0d4a30ff38e46b709ae671cff74ad89f5d82530eb17
   languageName: node
   linkType: hard
 
@@ -8014,7 +8026,7 @@ __metadata:
     "@ionic/angular": "npm:^8.0.0"
     "@ionic/angular-toolkit": "npm:^10.0.0"
     "@ionic/cli": "npm:^7.2.1"
-    "@sentry/angular": "npm:10.60.0"
+    "@sentry/angular": "npm:10.69.0"
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor"
     "@sentry/cli": "npm:^2.58.6"
     "@types/jasmine": "npm:~5.1.0"

--- a/example/ionic-vue3/ios/App/CapApp-SPM/Package.swift
+++ b/example/ionic-vue3/ios/App/CapApp-SPM/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(name: "CapacitorHaptics", path: "../../../node_modules/@capacitor/haptics"),
         .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
         .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
-        .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
+        .package(name: "SentryCapacitor", path: "../../../.yalc/@sentry/capacitor")
     ],
     targets: [
         .target(

--- a/example/ionic-vue3/package.json
+++ b/example/ionic-vue3/package.json
@@ -30,7 +30,7 @@
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor",
     "@sentry/cli": "^2.58.6",
     "@sentry/vite-plugin": "^5.1.1",
-    "@sentry/vue": "10.60.0",
+    "@sentry/vue": "10.69.0",
     "brace-expansion": "5.0.8",
     "ionicons": "^8.0.0",
     "vue": "^3.5.0",

--- a/example/ionic-vue3/yarn.lock
+++ b/example/ionic-vue3/yarn.lock
@@ -2513,25 +2513,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser-utils@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser-utils@npm:10.60.0"
+"@sentry/browser-utils@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser-utils@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/a8da259fca9513143c7eb2946a6c1cefbf3e844b57978ebf8f1fd52515ee10ec0a9237f73ccaad69e684ffabc60805014a13eb895c6f477cfa2417cdebf479f7
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/2b4a1429e39e48ba4729f30fae4dd217a42203c69e114fcbe3633b5690ca1ea65658b25e7e2a03c5b2df7b62362930e9d1ac648b0653f89058fd1c4f56df55df
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser@npm:10.60.0"
+"@sentry/browser@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/feedback": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-    "@sentry/replay-canvas": "npm:10.60.0"
-  checksum: 10c0/63ff8d70a2fe365ee3fa859c54715defcf08bb5ae8a56fb153826f2a4088d6307b3fa1c19e3d0cfd4d8145cdd1addd71c4157515c5c13251d93a45c4d59ff9b1
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/feedback": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+    "@sentry/replay-canvas": "npm:10.69.0"
+  checksum: 10c0/0a0c2cdf0801b92bb274f74cba9b0d3cc660f2b3fd85937c3b6e9eb9021799dc8bf015b72ac3ece29a63c437a2dbe7dc13d559220f81742b8212ec2b56a89912
   languageName: node
   linkType: hard
 
@@ -2551,17 +2553,17 @@ __metadata:
   linkType: hard
 
 "@sentry/capacitor@file:.yalc/@sentry/capacitor::locator=ionic-vue3%40workspace%3A.":
-  version: 4.1.0+2f79fdca
-  resolution: "@sentry/capacitor@file:.yalc/@sentry/capacitor#.yalc/@sentry/capacitor::hash=816988&locator=ionic-vue3%40workspace%3A."
+  version: 4.2.0+c5265af2
+  resolution: "@sentry/capacitor@file:.yalc/@sentry/capacitor#.yalc/@sentry/capacitor::hash=9385cf&locator=ionic-vue3%40workspace%3A."
   dependencies:
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/types": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/types": "npm:10.69.0"
   peerDependencies:
     "@capacitor/core": ">=3.0.0"
-    "@sentry/angular": 10.60.0
-    "@sentry/react": 10.60.0
-    "@sentry/vue": 10.60.0
+    "@sentry/angular": 10.69.0
+    "@sentry/react": 10.69.0
+    "@sentry/vue": 10.69.0
   peerDependenciesMeta:
     "@sentry/angular":
       optional: true
@@ -2569,7 +2571,7 @@ __metadata:
       optional: true
     "@sentry/vue":
       optional: true
-  checksum: 10c0/e5f9be2a5206dd3cc5304fa1f8d05fe1709c8c0c39f8a0ac4601adf1b0f51468488a39e662de8c16e8b773e5f8e1c6ebf61e5edabaec6d48d029bad4788682b8
+  checksum: 10c0/88f200d15caad270881a28141e6b238e02b2ed0165def75440c0b74cabbf31b80ffccff216d446bcf3d2f3d15afa8004382b7147350c2f49f6ac74f9a7c6d179
   languageName: node
   linkType: hard
 
@@ -2765,39 +2767,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/core@npm:10.60.0"
-  checksum: 10c0/7b34d28e35258aafba1302cfaffa1e147dfc11cf813ad88c6faeb29059d47bb66ad59c38cbd569f9e281c3c4fa46ff99d2a602ab0b100db67186e276997bbae2
+"@sentry/conventions@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@sentry/conventions@npm:0.16.0"
+  checksum: 10c0/415aaa94cade2b8e0dd00ad9aa06d998d7fe95658a8f43b6e4ef382e3b4c115c8f199ca0fe9b74a98500e8270dc68d5333fd943f7dad6ed78f60d9372231fbe8
   languageName: node
   linkType: hard
 
-"@sentry/feedback@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/feedback@npm:10.60.0"
+"@sentry/core@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/core@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/46880a893dd64ff9758e492851683606c0bc575ba1829a031983e919a30d7c72cf5cc3fd80ee4884f80a114df61cb976a0625013f5d8f04bdff0ba4bd94bb48f
+    "@sentry/conventions": "npm:^0.16.0"
+  checksum: 10c0/d6a00824a12d332063ed309c3fc263715ac1d20d253ddfce75d22b8b046da4eb2f99d843628bf365281ca625826bc6a9bdf5dec0ce24c9eb88712f7187858891
   languageName: node
   linkType: hard
 
-"@sentry/replay-canvas@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay-canvas@npm:10.60.0"
+"@sentry/feedback@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/feedback@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-  checksum: 10c0/d531cfb682f68bb5bb236ccc84a8a80eb1163dcba0c69629b7115ff03dffc8a23d2c50e41c749925fe0ca2e6fe91931529fb41f5de0c85f2722a90e3287a77d2
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/397c463bf47054c7210355eeebb81048f21f5b6d8af5e835e514eebebf670e49aa4fc07c73cbf0327a5ed88fd250a131a8045c024f164dac7587c02eb3cd0be7
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay@npm:10.60.0"
+"@sentry/replay-canvas@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay-canvas@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/b8c6199153ea4d5949f83f38c797aba7a3037d1edcd6874210b0d0e6ee269b9bbfa6275b0af9dd100e872db847902b610cd6fe914458a032de9aff95bf23c757
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+  checksum: 10c0/25f42d13a534c5608cc0c01624068c5f08e3157c309e53cf5a5788fa89ec66bcf706c649ff4d94240b879e8a62036813acd4416a3072eea88cd98663bfe91fb7
+  languageName: node
+  linkType: hard
+
+"@sentry/replay@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay@npm:10.69.0"
+  dependencies:
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/3c3918a037b9c1f8dc1d06b0cc456338d2316b10cef6ad42cc9154534631f48f47c4398fc503ad1d814326c489a075742e676abf27a61b3443c71265dcdadf30
   languageName: node
   linkType: hard
 
@@ -2813,12 +2824,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/types@npm:10.60.0"
+"@sentry/types@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/types@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/ab61ca95336b21530242e89f6cc252c8ae65d43473b8ed73dea0cd951f938cea586685ed75127dde075ebcdc0c5388a86b360c9eb6f6bcd299ed6c1bcb67e6bf
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/be2c617dd2fd9a5d9f9a2eae004581028460b2857fe5dd0e0016313853e5a4b7a36f9361f477e2984c9bb0d4a30ff38e46b709ae671cff74ad89f5d82530eb17
   languageName: node
   linkType: hard
 
@@ -2832,22 +2843,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/vue@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/vue@npm:10.60.0"
+"@sentry/vue@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/vue@npm:10.69.0"
   dependencies:
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
   peerDependencies:
     "@tanstack/vue-router": ^1.64.0
-    pinia: 2.x || 3.x
+    pinia: 2.x || 3.x || 4.x
     vue: 2.x || 3.x
   peerDependenciesMeta:
     "@tanstack/vue-router":
       optional: true
     pinia:
       optional: true
-  checksum: 10c0/4ba3d8da422758a5be05ced0ba452aaa25d28c590b82e31cd0d67ee2e7c9d70f5b63d0a4497b9db2d631feb14d0519854fd68640cc065bbfd721bbee717a7fd4
+  checksum: 10c0/4f09ab4e9cea530ae539d12b56bff5bfb85612279f85af22876ae12e203655277af738d1821051b9d9e877e4a08e89f6dcd5ed9be5590a518cfaa5549da48f5c
   languageName: node
   linkType: hard
 
@@ -5569,7 +5581,7 @@ __metadata:
     "@sentry/capacitor": "file:.yalc/@sentry/capacitor"
     "@sentry/cli": "npm:^2.58.6"
     "@sentry/vite-plugin": "npm:^5.1.1"
-    "@sentry/vue": "npm:10.60.0"
+    "@sentry/vue": "npm:10.69.0"
     "@vitejs/plugin-legacy": "npm:^7.0.0"
     "@vitejs/plugin-vue": "npm:^6.0.0"
     "@vue/eslint-config-typescript": "npm:^14.0.0"

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   "license": "MIT",
   "peerDependencies": {
     "@capacitor/core": ">=3.0.0",
-    "@sentry/angular": "10.60.0",
-    "@sentry/react": "10.60.0",
-    "@sentry/vue": "10.60.0"
+    "@sentry/angular": "10.69.0",
+    "@sentry/react": "10.69.0",
+    "@sentry/vue": "10.69.0"
   },
   "peerDependenciesMeta": {
     "@sentry/angular": {
@@ -58,9 +58,9 @@
     }
   },
   "dependencies": {
-    "@sentry/browser": "10.60.0",
-    "@sentry/core": "10.60.0",
-    "@sentry/types": "10.60.0"
+    "@sentry/browser": "10.69.0",
+    "@sentry/core": "10.69.0",
+    "@sentry/types": "10.69.0"
   },
   "devDependencies": {
     "@capacitor/android": "^6.0.0 || ^7.0.0 || ^8.0.0",

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -12,17 +12,12 @@ const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript|electron)(
  * @return {Boolean} true if requested to skip the post-install check, false otherwise.
  */
 function SkipPostInstall() {
-  if (env.UPDATE_SENTRY_CAPACITOR) {
-    // Internal bump scripts (env var, since Yarn 4/Berry rejects unrecognized CLI flags
-    // like --update-sentry-capacitor on `yarn add`/`yarn up`).
-    return true;
-  }
   if (env.npm_config_update_sentry_capacitor) {
     // NPM.
     return true;
   }
   else if (env.npm_config_argv && env.npm_config_argv.includes(updateArgument)) {
-    // YARN Classic.
+    // YARN.
     return true;
   }
   return false;

--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -12,12 +12,17 @@ const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript|electron)(
  * @return {Boolean} true if requested to skip the post-install check, false otherwise.
  */
 function SkipPostInstall() {
+  if (env.UPDATE_SENTRY_CAPACITOR) {
+    // Internal bump scripts (env var, since Yarn 4/Berry rejects unrecognized CLI flags
+    // like --update-sentry-capacitor on `yarn add`/`yarn up`).
+    return true;
+  }
   if (env.npm_config_update_sentry_capacitor) {
     // NPM.
     return true;
   }
   else if (env.npm_config_argv && env.npm_config_argv.includes(updateArgument)) {
-    // YARN.
+    // YARN Classic.
     return true;
   }
   return false;

--- a/scripts/update-javascript-siblings.sh
+++ b/scripts/update-javascript-siblings.sh
@@ -5,15 +5,21 @@ scriptDir="$(cd "$(dirname "$0")" && pwd)"
 rootDir="$(cd "$scriptDir/.." && pwd)"
 
 tagPrefix=''
-updatePeerPackages=1
+# @sentry/react|vue|angular are real peerDependencies of the SDK itself, but plain
+# regular dependencies in the sample apps under example/ - only use `yarn add --peer`
+# at the SDK root.
+if [[ "$rootDir" == */example/* ]]; then
+    updatePeerPackages=0
+else
+    updatePeerPackages=1
+fi
 repo="https://github.com/getsentry/sentry-javascript.git"
 packages=('@sentry/react' '@sentry/vue' '@sentry/angular')
 
 . "$scriptDir/update-package-json.sh"
 
 # Update sample apps if they need any update
-if [[ "$scriptDir" == "$rootDir/scripts" ]]; then
-    updatePeerPackages=0
+if [[ "$rootDir" != */example/* ]]; then
     if [[ "${1:-}" == "set-version" ]]; then
         for sampleScript in "$rootDir"/example/ionic-*/scripts/update-javascript-siblings.sh; do
             if [[ -f "$sampleScript" ]]; then

--- a/scripts/update-package-json.sh
+++ b/scripts/update-package-json.sh
@@ -34,9 +34,9 @@ set-version)
             cd "$(dirname "$file")"
             if [ "$updatePeerPackages" -eq 1 ]; then
                 #upgrade doesn't support peerDependencies so we'll use the yarn option.
-                yarn add --peer $list --update-sentry-capacitor
+                UPDATE_SENTRY_CAPACITOR=1 yarn add --peer $list
             else
-                yarn up $list --update-sentry-capacitor
+                UPDATE_SENTRY_CAPACITOR=1 yarn up $list
             fi
         )
     fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,25 +1084,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser-utils@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser-utils@npm:10.60.0"
+"@sentry/browser-utils@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser-utils@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/a8da259fca9513143c7eb2946a6c1cefbf3e844b57978ebf8f1fd52515ee10ec0a9237f73ccaad69e684ffabc60805014a13eb895c6f477cfa2417cdebf479f7
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/2b4a1429e39e48ba4729f30fae4dd217a42203c69e114fcbe3633b5690ca1ea65658b25e7e2a03c5b2df7b62362930e9d1ac648b0653f89058fd1c4f56df55df
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/browser@npm:10.60.0"
+"@sentry/browser@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/browser@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/feedback": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-    "@sentry/replay-canvas": "npm:10.60.0"
-  checksum: 10c0/63ff8d70a2fe365ee3fa859c54715defcf08bb5ae8a56fb153826f2a4088d6307b3fa1c19e3d0cfd4d8145cdd1addd71c4157515c5c13251d93a45c4d59ff9b1
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/feedback": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+    "@sentry/replay-canvas": "npm:10.69.0"
+  checksum: 10c0/0a0c2cdf0801b92bb274f74cba9b0d3cc660f2b3fd85937c3b6e9eb9021799dc8bf015b72ac3ece29a63c437a2dbe7dc13d559220f81742b8212ec2b56a89912
   languageName: node
   linkType: hard
 
@@ -1114,11 +1116,11 @@ __metadata:
     "@capacitor/core": "npm:^6.0.0  || ^7.0.0 || ^8.0.0"
     "@capacitor/ios": "npm:^6.0.0  || ^7.0.0 || ^8.0.0"
     "@ionic/prettier-config": "npm:^1.0.0"
-    "@sentry/browser": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
+    "@sentry/browser": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
     "@sentry/eslint-config-sdk": "npm:10.60.0"
     "@sentry/eslint-plugin-sdk": "npm:10.60.0"
-    "@sentry/types": "npm:10.60.0"
+    "@sentry/types": "npm:10.69.0"
     "@sentry/typescript": "npm:10.60.0"
     "@sentry/wizard": "npm:^6.12.0"
     "@types/jest": "npm:^29.5.3"
@@ -1134,9 +1136,9 @@ __metadata:
     typescript: "npm:5.8.3"
   peerDependencies:
     "@capacitor/core": ">=3.0.0"
-    "@sentry/angular": 10.60.0
-    "@sentry/react": 10.60.0
-    "@sentry/vue": 10.60.0
+    "@sentry/angular": 10.69.0
+    "@sentry/react": 10.69.0
+    "@sentry/vue": 10.69.0
   peerDependenciesMeta:
     "@sentry/angular":
       optional: true
@@ -1154,10 +1156,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/core@npm:10.60.0"
-  checksum: 10c0/7b34d28e35258aafba1302cfaffa1e147dfc11cf813ad88c6faeb29059d47bb66ad59c38cbd569f9e281c3c4fa46ff99d2a602ab0b100db67186e276997bbae2
+"@sentry/conventions@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@sentry/conventions@npm:0.16.0"
+  checksum: 10c0/415aaa94cade2b8e0dd00ad9aa06d998d7fe95658a8f43b6e4ef382e3b4c115c8f199ca0fe9b74a98500e8270dc68d5333fd943f7dad6ed78f60d9372231fbe8
   languageName: node
   linkType: hard
 
@@ -1165,6 +1167,15 @@ __metadata:
   version: 10.63.0
   resolution: "@sentry/core@npm:10.63.0"
   checksum: 10c0/1efa658c0708abbc8a3fb8b351fcb16028e54d4eb0f63a99d91a6137cecdcb45f0c0a691ffa7b80b06f5d8715784e2929e34e40fa505ba70c67c4c25834549d0
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/core@npm:10.69.0"
+  dependencies:
+    "@sentry/conventions": "npm:^0.16.0"
+  checksum: 10c0/d6a00824a12d332063ed309c3fc263715ac1d20d253ddfce75d22b8b046da4eb2f99d843628bf365281ca625826bc6a9bdf5dec0ce24c9eb88712f7187858891
   languageName: node
   linkType: hard
 
@@ -1194,12 +1205,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/feedback@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/feedback@npm:10.60.0"
+"@sentry/feedback@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/feedback@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/46880a893dd64ff9758e492851683606c0bc575ba1829a031983e919a30d7c72cf5cc3fd80ee4884f80a114df61cb976a0625013f5d8f04bdff0ba4bd94bb48f
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/397c463bf47054c7210355eeebb81048f21f5b6d8af5e835e514eebebf670e49aa4fc07c73cbf0327a5ed88fd250a131a8045c024f164dac7587c02eb3cd0be7
   languageName: node
   linkType: hard
 
@@ -1264,23 +1275,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/replay-canvas@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay-canvas@npm:10.60.0"
+"@sentry/replay-canvas@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay-canvas@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-    "@sentry/replay": "npm:10.60.0"
-  checksum: 10c0/d531cfb682f68bb5bb236ccc84a8a80eb1163dcba0c69629b7115ff03dffc8a23d2c50e41c749925fe0ca2e6fe91931529fb41f5de0c85f2722a90e3287a77d2
+    "@sentry/core": "npm:10.69.0"
+    "@sentry/replay": "npm:10.69.0"
+  checksum: 10c0/25f42d13a534c5608cc0c01624068c5f08e3157c309e53cf5a5788fa89ec66bcf706c649ff4d94240b879e8a62036813acd4416a3072eea88cd98663bfe91fb7
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/replay@npm:10.60.0"
+"@sentry/replay@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/replay@npm:10.69.0"
   dependencies:
-    "@sentry/browser-utils": "npm:10.60.0"
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/b8c6199153ea4d5949f83f38c797aba7a3037d1edcd6874210b0d0e6ee269b9bbfa6275b0af9dd100e872db847902b610cd6fe914458a032de9aff95bf23c757
+    "@sentry/browser-utils": "npm:10.69.0"
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/3c3918a037b9c1f8dc1d06b0cc456338d2316b10cef6ad42cc9154534631f48f47c4398fc503ad1d814326c489a075742e676abf27a61b3443c71265dcdadf30
   languageName: node
   linkType: hard
 
@@ -1298,12 +1309,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:10.60.0":
-  version: 10.60.0
-  resolution: "@sentry/types@npm:10.60.0"
+"@sentry/types@npm:10.69.0":
+  version: 10.69.0
+  resolution: "@sentry/types@npm:10.69.0"
   dependencies:
-    "@sentry/core": "npm:10.60.0"
-  checksum: 10c0/ab61ca95336b21530242e89f6cc252c8ae65d43473b8ed73dea0cd951f938cea586685ed75127dde075ebcdc0c5388a86b360c9eb6f6bcd299ed6c1bcb67e6bf
+    "@sentry/core": "npm:10.69.0"
+  checksum: 10c0/be2c617dd2fd9a5d9f9a2eae004581028460b2857fe5dd0e0016313853e5a4b7a36f9361f477e2984c9bb0d4a30ff38e46b709ae671cff74ad89f5d82530eb17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Bumps the Sentry JavaScript SDK from `10.60.0` to `10.69.0`:
- `@sentry/browser`, `@sentry/core`, `@sentry/types` (root `dependencies`)
- `@sentry/angular`, `@sentry/react`, `@sentry/vue` (root `peerDependencies`, and the sample apps' regular `dependencies`)
- Republished `@sentry/capacitor` via yalc and relinked/rebuilt/`cap sync`'d it into all three sample apps (`ionic-angular-v7`, `ionic-angular-v8`, `ionic-vue3`).

Also fixes `scripts/update-package-json.sh` and `scripts/update-javascript-siblings.sh`, which broke under Yarn 4/Berry after the recent Yarn Classic → Yarn 4 migration (#1318) and were silently never exercised end-to-end since:
- The `--update-sentry-capacitor` sentinel flag passed to `yarn add`/`yarn up` is now passed as an `UPDATE_SENTRY_CAPACITOR` env var instead. Berry hard-rejects unrecognized CLI flags, where Yarn Classic silently ignored them; `scripts/check-siblings.js`'s `SkipPostInstall()` now also checks the env var.
- `updatePeerPackages` was hardcoded to `1` regardless of context, so the sample apps' `@sentry/angular`/`react`/`vue` (plain `dependencies` there, not peer deps) were being upgraded via `yarn add --peer`, which Berry rejects. Now scoped correctly to the SDK root vs. `example/*`.

## :bulb: Motivation and Context
Routine dependency bump to pick up the latest Sentry JavaScript SDK fixes and features. Reviewed the upstream changelog for the `10.61.0`–`10.69.0` range against what this SDK actually wires up (`functionToStringIntegration`, `browserSessionIntegration`, etc.) — nothing breaking; the one default-behavior change worth knowing about is `streamGenAiSpans` defaulting to `true` as of `10.61.0`, which self-hosted Sentry users may need to opt out of if they use AI tracing (not enabled by this SDK's own defaults).

## :green_heart: How did you test it?
- `yarn bump:javascript-version 10.69.0` (after fixing the Yarn 4 breakage) to bump the root SDK and all three sample apps.
- `yarn bump:samples` to republish `@sentry/capacitor` via yalc and relink/rebuild/`cap sync` each sample app; all three (`bump:v7`, `bump:v8`, `bump:sample-vue`) completed successfully.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps
