### PR TITLE
fix(scripts): Fix check-siblings.js postinstall advice for Yarn 4/Berry

### DIFF
--- a/scripts/check-siblings.js
+++ b/scripts/check-siblings.js
@@ -1,8 +1,16 @@
 const fs = require('fs');
 const path = require('path');
-const { env, exit } = require('process');
+const { env, exit, platform } = require('process');
 
-const updateArgument = '--update-sentry-capacitor';
+// Deprecated: a `--update-sentry-capacitor` CLI flag passed to `yarn add`/`npm install` to skip this
+// check during an intentional sibling bump. Yarn 2+ (Berry) rejects unrecognized CLI flags outright, so
+// this only ever worked on Yarn Classic and npm (which auto-converts unknown flags into `npm_config_*`
+// env vars for lifecycle scripts). Kept only for backwards compatibility; will be removed in the next
+// major version - use the `updateArgument` env var below instead.
+const legacyUpdateArgument = '--update-sentry-capacitor';
+// Environment variable that skips this check during an intentional sibling bump. Works the same way
+// regardless of package manager or Yarn version.
+const updateArgument = 'UPDATE_SENTRY_CAPACITOR';
 
 // Filters all Sentry packages but Capacitor, CLI and Wizard.
 const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript|electron)(?<packageName>[a-zA-Z]+)\"\:\s*\"(?<version>.+)\"/;
@@ -12,12 +20,15 @@ const jsonFilter = /\s*\"\@sentry\/(?!capacitor|wizard|cli|typescript|electron)(
  * @return {Boolean} true if requested to skip the post-install check, false otherwise.
  */
 function SkipPostInstall() {
-  if (env.npm_config_update_sentry_capacitor) {
-    // NPM.
+  if (env[updateArgument]) {
     return true;
   }
-  else if (env.npm_config_argv && env.npm_config_argv.includes(updateArgument)) {
-    // YARN.
+  if (env.npm_config_update_sentry_capacitor) {
+    // NPM, legacy --update-sentry-capacitor flag.
+    return true;
+  }
+  else if (env.npm_config_argv && env.npm_config_argv.includes(legacyUpdateArgument)) {
+    // Yarn Classic, legacy --update-sentry-capacitor flag.
     return true;
   }
   return false;
@@ -99,18 +110,22 @@ function GetPackageJsonRootPath() {
 }
 
 /**
- * @param {String} package The package.
- * @return {String} The path where package.json is located.
+ * @param {String} sentryPackages The sibling packages (with the required version) to install.
+ * @return {String} The command(s) to run, with `updateArgument` set, to install the given packages
+ * while skipping this check.
  */
 function FormatPackageInstallCommand(sentryPackages) {
   // Yarn V1 || Yarn V3/V4.
-  if (env.npm_config_argv || env.npm_config_user_agent?.startsWith('yarn')) {
-    return "yarn add --exact " + sentryPackages + " " + updateArgument;
+  const isYarn = env.npm_config_argv || env.npm_config_user_agent?.startsWith('yarn');
+  const command = isYarn
+    ? "yarn add --exact " + sentryPackages
+    : "npm install --save-exact " + sentryPackages;
+
+  if (platform === 'win32') {
+    return `set ${updateArgument}=1&& ${command}\n` +
+      `  or, in PowerShell: $env:${updateArgument}=1; ${command}`;
   }
-  else {
-    // NPM
-    return "npm install --save-exact " + sentryPackages + " " + updateArgument;
-  }
+  return `${updateArgument}=1 ${command}`;
 }
 
 function CheckSiblings() {
@@ -151,7 +166,7 @@ function CheckSiblings() {
       packagesList += sentryPackage[0] + '@' + siblingVersion + ' ';
     }
     IncompatibilityError.push(
-      `Please install the mentioned packages exactly with version ${siblingVersion} and with the argument ${updateArgument}.
+      `Please install the mentioned packages exactly with version ${siblingVersion} and with the environment variable ${updateArgument} set.
 Your project will build with the wrong package but you may face Runtime errors.
 You can use the below command to fix your package.json:`);
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
`scripts/check-siblings.js` runs as this package's `postinstall` hook and, when it detects a sibling (`@sentry/angular`/`react`/`vue`/`browser`/etc.) version mismatch, prints a suggested fix-it command via `FormatPackageInstallCommand()`. That command appended a `--update-sentry-capacitor` CLI flag to `yarn add`/`npm install` to intentionally skip the check.

Yarn 2+ (Berry) rejects unrecognized CLI flags outright, so on Yarn 4/Berry the suggested command fails with a cryptic `Unknown Syntax Error: Command not found` instead of fixing anything. This flag only ever worked on Yarn Classic and npm, since npm auto-converts unknown flags into `npm_config_*` env vars for lifecycle scripts, and Yarn Classic exposes the raw argv (`npm_config_argv`) to those scripts too — Berry does neither.

`FormatPackageInstallCommand()` now always suggests setting an `UPDATE_SENTRY_CAPACITOR` environment variable instead of passing a CLI flag, which works identically across npm, Yarn Classic and Yarn Berry, with separate `cmd.exe`/PowerShell syntax shown on Windows. The old `--update-sentry-capacitor` flag is renamed to `legacyUpdateArgument` and kept only for backwards compatibility (still recognized by `SkipPostInstall` on npm and Yarn Classic); it will be removed in the next major version. The incompatibility error message now says "environment variable" instead of "argument".

## :bulb: Motivation and Context
Found while bumping the JS SDK to 10.69.0 (#1354) on this Yarn-4-migrated repo: our own internal bump scripts hit the exact same "Berry rejects the flag" failure, which led to auditing `check-siblings.js` and finding this same flag is also embedded in the published package's postinstall advice, affecting any consumer on Yarn 4/Berry with a mismatched sibling version.

## :green_heart: How did you test it?
- Loaded the script standalone (`node -e "require('./scripts/check-siblings.js')"`) to confirm it parses and runs without errors.
- Simulated `FormatPackageInstallCommand()`'s output for both POSIX and `win32` platforms to confirm the generated commands are correct:
  - POSIX: `UPDATE_SENTRY_CAPACITOR=1 yarn add --exact @sentry/angular@10.69.0`
  - Windows: `set UPDATE_SENTRY_CAPACITOR=1&& yarn add --exact @sentry/angular@10.69.0` plus a PowerShell alternative line.
- Reproduced the original failure directly against Yarn 4.17.0 (`yarn add --exact lodash@4.18.1 --update-sentry-capacitor` → `Unknown Syntax Error`) to confirm the root cause before fixing.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps
Remove `legacyUpdateArgument` and the npm/Yarn-Classic-flag branches in `SkipPostInstall()` in the next major version.
