### PR TITLE
fix(ci): Fix release artifact upload after Yarn 4 migration

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -152,11 +152,12 @@ jobs:
           key: ${{ env.BUILD_CACHE_KEY }}
           enableCrossOsArchive: true
       - name: Pack
-        run: yarn pack
+        run: yarn pack -o "sentry-capacitor-%v.tgz"
       - name: Archive artifacts
         uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
         with:
           name: ${{ github.sha }}
+          if-no-files-found: error
           path: |
             ${{ github.workspace }}/sentry-capacitor-*
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
`job_artifacts` in `buildandtest.yml` runs `yarn pack` and then uploads whatever matches the glob `sentry-capacitor-*` as the artifact craft downloads to publish a release. Since the Yarn Classic → Yarn 4 migration (#1318), `yarn pack` writes to `package.tgz` by default instead of `sentry-capacitor-<version>.tgz`, so the glob matches nothing.

This changes the pack step to explicitly name the output `sentry-capacitor-<version>.tgz` via `yarn pack -o "sentry-capacitor-%v.tgz"`, and adds `if-no-files-found: error` to the upload step so a similar mismatch fails CI loudly instead of silently reporting green with no artifact uploaded.

## :bulb: Motivation and Context
`craft publish` failed on revision `2ca8134` with:
```
[error] [[artifact-provider/github]] Unable to retrieve artifact list for revision 2ca8134a59f5c621de767c0e0e5ea9858505c6d5!
[error] Can't find any artifacts for revision "2ca8134a59f5c621de767c0e0e5ea9858505c6d5" (tries: 3)
```
Root cause: the "Archive artifacts" step's `path: sentry-capacitor-*` glob didn't match `package.tgz` (Yarn 4's default pack output), so `actions/upload-artifact` uploaded nothing but the job still reported success (`if-no-files-found` defaulted to `warn`). craft's status check saw a green build but there was no artifact to fetch for that commit SHA.

## :green_heart: How did you test it?
Ran `yarn pack -o "sentry-capacitor-%v.tgz"` locally and confirmed it produces `sentry-capacitor-4.2.0.tgz`, which matches the `sentry-capacitor-*` glob used by the upload step.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [x] No breaking changes

## :crystal_ball: Next steps
None — CI on this PR will produce a real artifact named after this commit's SHA, which can be used to confirm the fix end-to-end.