### PR TITLE
Update peer dependency for @capacitor/core to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Sentry Team and Contributors",
   "license": "MIT",
   "peerDependencies": {
-    "@capacitor/core": ">=3.0.0",
+    "@capacitor/core": ">=6.0.0",
     "@sentry/angular": "10.69.0",
     "@sentry/react": "10.69.0",
     "@sentry/vue": "10.69.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,7 +1135,7 @@ __metadata:
     ts-jest: "npm:^29.1.1"
     typescript: "npm:5.8.3"
   peerDependencies:
-    "@capacitor/core": ">=3.0.0"
+    "@capacitor/core": ">=6.0.0"
     "@sentry/angular": 10.69.0
     "@sentry/react": 10.69.0
     "@sentry/vue": 10.69.0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This package dropped support for old Capacitor versions (3.x, 4,x 5x) in #907, but `peerDependency` stayed as `>=3`, probably as an oversight.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For example [here](https://npmx.dev/package/@sentry/capacitor/) (Peer Dependency section) it might look that current package version still supports old Capacitor versions.

## :green_heart: How did you test it?
Did not test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec
- [ ] No breaking changes

## :crystal_ball: Next steps
In my opinion the version range `>=` is too broad and it should list each major, just as in `devDependencies` section does as it is not known if this package will work with Capacitor v9:

https://github.com/getsentry/sentry-capacitor/blob/0a6c29578534ab528d7760db76d24ca224592991/package.json#L65-L68

